### PR TITLE
Refine storefront facelets with accessible Bootstrap layout

### DIFF
--- a/veristore/pom.xml
+++ b/veristore/pom.xml
@@ -1,0 +1,180 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.theplutushome</groupId>
+    <artifactId>veristore</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <packaging>war</packaging>
+
+    <name>veristore</name>
+    <description>Veristore web application</description>
+
+    <properties>
+        <java.version>17</java.version>
+        <jakarta.platform.version>10.0.0</jakarta.platform.version>
+        <jersey.version>3.1.5</jersey.version>
+        <mojarra.version>4.0.4</mojarra.version>
+        <hibernate.version>6.4.4.Final</hibernate.version>
+        <mapstruct.version>1.5.5.Final</mapstruct.version>
+        <lombok.version>1.18.32</lombok.version>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.release>${java.version}</maven.compiler.release>
+        <hibernate.show_sql>false</hibernate.show_sql>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>jakarta.platform</groupId>
+                <artifactId>jakarta.jakartaee-bom</artifactId>
+                <version>${jakarta.platform.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>jakarta.platform</groupId>
+            <artifactId>jakarta.jakartaee-web-api</artifactId>
+            <version>${jakarta.platform.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.glassfish</groupId>
+            <artifactId>jakarta.faces</artifactId>
+            <version>${mojarra.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.hibernate.orm</groupId>
+            <artifactId>hibernate-core</artifactId>
+            <version>${hibernate.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.glassfish.jersey.containers</groupId>
+            <artifactId>jersey-container-servlet</artifactId>
+            <version>${jersey.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.inject</groupId>
+            <artifactId>jersey-hk2</artifactId>
+            <version>${jersey.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.sun.mail</groupId>
+            <artifactId>jakarta.mail</artifactId>
+            <version>2.0.1</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <version>${lombok.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.mapstruct</groupId>
+            <artifactId>mapstruct</artifactId>
+            <version>${mapstruct.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.mapstruct</groupId>
+            <artifactId>mapstruct-processor</artifactId>
+            <version>${mapstruct.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.10.2</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <finalName>${project.artifactId}</finalName>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.11.0</version>
+                <configuration>
+                    <release>${maven.compiler.release}</release>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                            <version>${lombok.version}</version>
+                        </path>
+                        <path>
+                            <groupId>org.mapstruct</groupId>
+                            <artifactId>mapstruct-processor</artifactId>
+                            <version>${mapstruct.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-war-plugin</artifactId>
+                <version>3.4.0</version>
+                <configuration>
+                    <failOnMissingWebXml>false</failOnMissingWebXml>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.2.5</version>
+                <configuration>
+                    <useModulePath>false</useModulePath>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>dev</id>
+            <properties>
+                <hibernate.show_sql>true</hibernate.show_sql>
+            </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>com.h2database</groupId>
+                    <artifactId>h2</artifactId>
+                    <version>2.2.224</version>
+                    <scope>runtime</scope>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
+            <id>prod</id>
+            <dependencies>
+                <dependency>
+                    <groupId>org.postgresql</groupId>
+                    <artifactId>postgresql</artifactId>
+                    <version>42.7.2</version>
+                    <scope>runtime</scope>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
+</project>

--- a/veristore/src/main/java/com/theplutushome/veristore/config/AppConfig.java
+++ b/veristore/src/main/java/com/theplutushome/veristore/config/AppConfig.java
@@ -1,0 +1,8 @@
+package com.theplutushome.veristore.config;
+
+import jakarta.ws.rs.ApplicationPath;
+import jakarta.ws.rs.core.Application;
+
+@ApplicationPath("/api")
+public class AppConfig extends Application {
+}

--- a/veristore/src/main/java/com/theplutushome/veristore/config/package-info.java
+++ b/veristore/src/main/java/com/theplutushome/veristore/config/package-info.java
@@ -1,0 +1,1 @@
+package com.theplutushome.veristore.$pkg;

--- a/veristore/src/main/java/com/theplutushome/veristore/delivery/package-info.java
+++ b/veristore/src/main/java/com/theplutushome/veristore/delivery/package-info.java
@@ -1,0 +1,1 @@
+package com.theplutushome.veristore.$pkg;

--- a/veristore/src/main/java/com/theplutushome/veristore/dto/CartLineDTO.java
+++ b/veristore/src/main/java/com/theplutushome/veristore/dto/CartLineDTO.java
@@ -1,0 +1,97 @@
+package com.theplutushome.veristore.dto;
+
+import java.io.Serial;
+import java.io.Serializable;
+
+public class CartLineDTO implements Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
+
+    private String sku;
+    private String name;
+    private int qty;
+    private long unitPriceMinor;
+    private long totalMinor;
+    private String priceFormatted;
+    private String totalFormatted;
+    private String currency;
+
+    public CartLineDTO() {
+    }
+
+    public CartLineDTO(CartLineDTO other) {
+        this.sku = other.sku;
+        this.name = other.name;
+        this.qty = other.qty;
+        this.unitPriceMinor = other.unitPriceMinor;
+        this.totalMinor = other.totalMinor;
+        this.priceFormatted = other.priceFormatted;
+        this.totalFormatted = other.totalFormatted;
+        this.currency = other.currency;
+    }
+
+    public String getSku() {
+        return sku;
+    }
+
+    public void setSku(String sku) {
+        this.sku = sku;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public int getQty() {
+        return qty;
+    }
+
+    public void setQty(int qty) {
+        this.qty = qty;
+    }
+
+    public long getUnitPriceMinor() {
+        return unitPriceMinor;
+    }
+
+    public void setUnitPriceMinor(long unitPriceMinor) {
+        this.unitPriceMinor = unitPriceMinor;
+    }
+
+    public long getTotalMinor() {
+        return totalMinor;
+    }
+
+    public void setTotalMinor(long totalMinor) {
+        this.totalMinor = totalMinor;
+    }
+
+    public String getPriceFormatted() {
+        return priceFormatted;
+    }
+
+    public void setPriceFormatted(String priceFormatted) {
+        this.priceFormatted = priceFormatted;
+    }
+
+    public String getTotalFormatted() {
+        return totalFormatted;
+    }
+
+    public void setTotalFormatted(String totalFormatted) {
+        this.totalFormatted = totalFormatted;
+    }
+
+    public String getCurrency() {
+        return currency;
+    }
+
+    public void setCurrency(String currency) {
+        this.currency = currency;
+    }
+}

--- a/veristore/src/main/java/com/theplutushome/veristore/dto/ProductCardDTO.java
+++ b/veristore/src/main/java/com/theplutushome/veristore/dto/ProductCardDTO.java
@@ -1,0 +1,83 @@
+package com.theplutushome.veristore.dto;
+
+import java.io.Serial;
+import java.io.Serializable;
+
+public class ProductCardDTO implements Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
+
+    private Long id;
+    private String sku;
+    private String name;
+    private String shortDesc;
+    private String country;
+    private String category;
+    private String priceFormatted;
+    private String thumbnailUrl;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getSku() {
+        return sku;
+    }
+
+    public void setSku(String sku) {
+        this.sku = sku;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getShortDesc() {
+        return shortDesc;
+    }
+
+    public void setShortDesc(String shortDesc) {
+        this.shortDesc = shortDesc;
+    }
+
+    public String getCountry() {
+        return country;
+    }
+
+    public void setCountry(String country) {
+        this.country = country;
+    }
+
+    public String getCategory() {
+        return category;
+    }
+
+    public void setCategory(String category) {
+        this.category = category;
+    }
+
+    public String getPriceFormatted() {
+        return priceFormatted;
+    }
+
+    public void setPriceFormatted(String priceFormatted) {
+        this.priceFormatted = priceFormatted;
+    }
+
+    public String getThumbnailUrl() {
+        return thumbnailUrl;
+    }
+
+    public void setThumbnailUrl(String thumbnailUrl) {
+        this.thumbnailUrl = thumbnailUrl;
+    }
+}

--- a/veristore/src/main/java/com/theplutushome/veristore/dto/ProductDetailDTO.java
+++ b/veristore/src/main/java/com/theplutushome/veristore/dto/ProductDetailDTO.java
@@ -1,0 +1,101 @@
+package com.theplutushome.veristore.dto;
+
+import java.io.Serial;
+import java.io.Serializable;
+
+public class ProductDetailDTO implements Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
+
+    private Long id;
+    private String sku;
+    private String name;
+    private String shortDesc;
+    private String longDesc;
+    private String country;
+    private String category;
+    private String priceFormatted;
+    private String imageUrl;
+    private String currency;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getSku() {
+        return sku;
+    }
+
+    public void setSku(String sku) {
+        this.sku = sku;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getShortDesc() {
+        return shortDesc;
+    }
+
+    public void setShortDesc(String shortDesc) {
+        this.shortDesc = shortDesc;
+    }
+
+    public String getLongDesc() {
+        return longDesc;
+    }
+
+    public void setLongDesc(String longDesc) {
+        this.longDesc = longDesc;
+    }
+
+    public String getCountry() {
+        return country;
+    }
+
+    public void setCountry(String country) {
+        this.country = country;
+    }
+
+    public String getCategory() {
+        return category;
+    }
+
+    public void setCategory(String category) {
+        this.category = category;
+    }
+
+    public String getPriceFormatted() {
+        return priceFormatted;
+    }
+
+    public void setPriceFormatted(String priceFormatted) {
+        this.priceFormatted = priceFormatted;
+    }
+
+    public String getImageUrl() {
+        return imageUrl;
+    }
+
+    public void setImageUrl(String imageUrl) {
+        this.imageUrl = imageUrl;
+    }
+
+    public String getCurrency() {
+        return currency;
+    }
+
+    public void setCurrency(String currency) {
+        this.currency = currency;
+    }
+}

--- a/veristore/src/main/java/com/theplutushome/veristore/dto/package-info.java
+++ b/veristore/src/main/java/com/theplutushome/veristore/dto/package-info.java
@@ -1,0 +1,1 @@
+package com.theplutushome.veristore.$pkg;

--- a/veristore/src/main/java/com/theplutushome/veristore/entity/Inventory.java
+++ b/veristore/src/main/java/com/theplutushome/veristore/entity/Inventory.java
@@ -1,0 +1,32 @@
+package com.theplutushome.veristore.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@ToString
+@Entity
+@Table(name = "inventory")
+public class Inventory {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true, length = 64)
+    private String sku;
+
+    @Column(nullable = false)
+    private Integer available;
+}

--- a/veristore/src/main/java/com/theplutushome/veristore/entity/Order.java
+++ b/veristore/src/main/java/com/theplutushome/veristore/entity/Order.java
@@ -1,0 +1,74 @@
+package com.theplutushome.veristore.entity;
+
+import java.time.OffsetDateTime;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@ToString
+@Entity
+@Table(name = "orders")
+public class Order {
+
+    public enum Status {
+        PENDING,
+        PAID,
+        FAILED,
+        DELIVERED,
+        REFUNDED
+    }
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "public_id", nullable = false, unique = true, length = 36)
+    private String publicId;
+
+    @Column(nullable = false, length = 256)
+    private String email;
+
+    @Column(length = 32)
+    private String phone;
+
+    @Column(name = "deliver_by_email", nullable = false)
+    private boolean deliverByEmail;
+
+    @Column(name = "deliver_by_sms", nullable = false)
+    private boolean deliverBySms;
+
+    @Column(name = "total_minor", nullable = false)
+    private Long totalMinor;
+
+    @Column(nullable = false, length = 3)
+    private String currency;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 16)
+    private Status status = Status.PENDING;
+
+    @Column(name = "created_at", nullable = false)
+    private OffsetDateTime createdAt;
+
+    @PrePersist
+    protected void onCreate() {
+        if (createdAt == null) {
+            createdAt = OffsetDateTime.now();
+        }
+    }
+}

--- a/veristore/src/main/java/com/theplutushome/veristore/entity/OrderLine.java
+++ b/veristore/src/main/java/com/theplutushome/veristore/entity/OrderLine.java
@@ -1,0 +1,44 @@
+package com.theplutushome.veristore.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@ToString
+@Entity
+@Table(name = "order_lines")
+public class OrderLine {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "order_id", nullable = false)
+    private Long orderId;
+
+    @Column(nullable = false, length = 64)
+    private String sku;
+
+    @Column(nullable = false, length = 160)
+    private String name;
+
+    @Column(nullable = false)
+    private Integer qty;
+
+    @Column(name = "unit_price_minor", nullable = false)
+    private Long unitPriceMinor;
+
+    @Column(name = "total_minor", nullable = false)
+    private Long totalMinor;
+}

--- a/veristore/src/main/java/com/theplutushome/veristore/entity/Product.java
+++ b/veristore/src/main/java/com/theplutushome/veristore/entity/Product.java
@@ -1,0 +1,59 @@
+package com.theplutushome.veristore.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@ToString
+@Entity
+@Table(name = "products")
+public class Product {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true, length = 64)
+    private String sku;
+
+    @Column(nullable = false, length = 160)
+    private String name;
+
+    @Column(name = "short_desc", length = 512)
+    private String shortDesc;
+
+    @Column(name = "long_desc", length = 4096)
+    private String longDesc;
+
+    @Column(length = 64)
+    private String country;
+
+    @Column(length = 128)
+    private String category;
+
+    @Column(name = "price_minor", nullable = false)
+    private Long priceMinor;
+
+    @Column(nullable = false, length = 3)
+    private String currency;
+
+    @Column(name = "image_url", length = 512)
+    private String imageUrl;
+
+    @Column(name = "thumbnail_url", length = 512)
+    private String thumbnailUrl;
+
+    @Column(nullable = false)
+    private boolean active = true;
+}

--- a/veristore/src/main/java/com/theplutushome/veristore/entity/SecretCode.java
+++ b/veristore/src/main/java/com/theplutushome/veristore/entity/SecretCode.java
@@ -1,0 +1,51 @@
+package com.theplutushome.veristore.entity;
+
+import java.time.OffsetDateTime;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@ToString
+@Entity
+@Table(name = "secret_codes")
+public class SecretCode {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "order_id", nullable = false)
+    private Long orderId;
+
+    @Column(nullable = false, length = 64)
+    private String sku;
+
+    @Column(nullable = false, length = 128)
+    private String code;
+
+    @Column(nullable = false)
+    private boolean delivered = false;
+
+    @Column(name = "created_at", nullable = false)
+    private OffsetDateTime createdAt;
+
+    @PrePersist
+    protected void onCreate() {
+        if (createdAt == null) {
+            createdAt = OffsetDateTime.now();
+        }
+    }
+}

--- a/veristore/src/main/java/com/theplutushome/veristore/entity/package-info.java
+++ b/veristore/src/main/java/com/theplutushome/veristore/entity/package-info.java
@@ -1,0 +1,1 @@
+package com.theplutushome.veristore.$pkg;

--- a/veristore/src/main/java/com/theplutushome/veristore/payment/PaymentService.java
+++ b/veristore/src/main/java/com/theplutushome/veristore/payment/PaymentService.java
@@ -1,0 +1,18 @@
+package com.theplutushome.veristore.payment;
+
+import java.io.Serial;
+import java.io.Serializable;
+import java.net.URI;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class PaymentService implements Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
+
+    public URI createInvoiceAndRedirect(long totalMinor, String currency) {
+        return URI.create("#psp-redirect");
+    }
+}

--- a/veristore/src/main/java/com/theplutushome/veristore/payment/package-info.java
+++ b/veristore/src/main/java/com/theplutushome/veristore/payment/package-info.java
@@ -1,0 +1,1 @@
+package com.theplutushome.veristore.$pkg;

--- a/veristore/src/main/java/com/theplutushome/veristore/repo/OrderLineRepo.java
+++ b/veristore/src/main/java/com/theplutushome/veristore/repo/OrderLineRepo.java
@@ -1,0 +1,47 @@
+package com.theplutushome.veristore.repo;
+
+import java.util.List;
+import java.util.Optional;
+
+import com.theplutushome.veristore.entity.OrderLine;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import jakarta.transaction.Transactional;
+
+@ApplicationScoped
+public class OrderLineRepo {
+
+    @PersistenceContext
+    EntityManager entityManager;
+
+    public Optional<OrderLine> findById(Long id) {
+        return Optional.ofNullable(entityManager.find(OrderLine.class, id));
+    }
+
+    public List<OrderLine> findByOrderId(Long orderId) {
+        return entityManager.createQuery(
+                        "SELECT ol FROM OrderLine ol WHERE ol.orderId = :orderId ORDER BY ol.id", OrderLine.class)
+                .setParameter("orderId", orderId)
+                .getResultList();
+    }
+
+    @Transactional
+    public OrderLine save(OrderLine orderLine) {
+        if (orderLine.getId() == null) {
+            entityManager.persist(orderLine);
+            return orderLine;
+        }
+        return entityManager.merge(orderLine);
+    }
+
+    @Transactional
+    public void delete(OrderLine orderLine) {
+        OrderLine managed = orderLine;
+        if (!entityManager.contains(orderLine)) {
+            managed = entityManager.merge(orderLine);
+        }
+        entityManager.remove(managed);
+    }
+}

--- a/veristore/src/main/java/com/theplutushome/veristore/repo/OrderRepo.java
+++ b/veristore/src/main/java/com/theplutushome/veristore/repo/OrderRepo.java
@@ -1,0 +1,53 @@
+package com.theplutushome.veristore.repo;
+
+import java.util.List;
+import java.util.Optional;
+
+import com.theplutushome.veristore.entity.Order;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import jakarta.persistence.TypedQuery;
+import jakarta.transaction.Transactional;
+
+@ApplicationScoped
+public class OrderRepo {
+
+    @PersistenceContext
+    EntityManager entityManager;
+
+    public Optional<Order> findById(Long id) {
+        return Optional.ofNullable(entityManager.find(Order.class, id));
+    }
+
+    public Optional<Order> findByPublicId(String publicId) {
+        TypedQuery<Order> query = entityManager.createQuery(
+                "SELECT o FROM Order o WHERE LOWER(o.publicId) = LOWER(:publicId)", Order.class);
+        query.setParameter("publicId", publicId);
+        return query.getResultStream().findFirst();
+    }
+
+    public List<Order> findAll() {
+        return entityManager.createQuery("SELECT o FROM Order o ORDER BY o.createdAt DESC", Order.class)
+                .getResultList();
+    }
+
+    @Transactional
+    public Order save(Order order) {
+        if (order.getId() == null) {
+            entityManager.persist(order);
+            return order;
+        }
+        return entityManager.merge(order);
+    }
+
+    @Transactional
+    public void delete(Order order) {
+        Order managed = order;
+        if (!entityManager.contains(order)) {
+            managed = entityManager.merge(order);
+        }
+        entityManager.remove(managed);
+    }
+}

--- a/veristore/src/main/java/com/theplutushome/veristore/repo/ProductRepo.java
+++ b/veristore/src/main/java/com/theplutushome/veristore/repo/ProductRepo.java
@@ -1,0 +1,88 @@
+package com.theplutushome.veristore.repo;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import com.theplutushome.veristore.entity.Product;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import jakarta.persistence.TypedQuery;
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Predicate;
+import jakarta.persistence.criteria.Root;
+import jakarta.transaction.Transactional;
+
+@ApplicationScoped
+public class ProductRepo {
+
+    @PersistenceContext
+    EntityManager entityManager;
+
+    public Optional<Product> findById(Long id) {
+        return Optional.ofNullable(entityManager.find(Product.class, id));
+    }
+
+    public Optional<Product> findBySku(String sku) {
+        CriteriaBuilder cb = entityManager.getCriteriaBuilder();
+        CriteriaQuery<Product> cq = cb.createQuery(Product.class);
+        Root<Product> root = cq.from(Product.class);
+        cq.select(root).where(cb.equal(cb.lower(root.get("sku")), sku.toLowerCase()));
+
+        List<Product> results = entityManager.createQuery(cq).setMaxResults(1).getResultList();
+        return results.stream().findFirst();
+    }
+
+    public List<Product> search(String country, String category, Long maxPriceMinor, int page, int size) {
+        CriteriaBuilder cb = entityManager.getCriteriaBuilder();
+        CriteriaQuery<Product> cq = cb.createQuery(Product.class);
+        Root<Product> root = cq.from(Product.class);
+
+        List<Predicate> predicates = new ArrayList<>();
+        predicates.add(cb.isTrue(root.get("active")));
+
+        if (country != null && !country.isBlank()) {
+            predicates.add(cb.equal(cb.lower(root.get("country")), country.toLowerCase()));
+        }
+
+        if (category != null && !category.isBlank()) {
+            predicates.add(cb.equal(cb.lower(root.get("category")), category.toLowerCase()));
+        }
+
+        if (maxPriceMinor != null) {
+            predicates.add(cb.lessThanOrEqualTo(root.get("priceMinor"), maxPriceMinor));
+        }
+
+        cq.select(root).where(predicates.toArray(new Predicate[0])).orderBy(cb.asc(root.get("name")));
+
+        TypedQuery<Product> query = entityManager.createQuery(cq);
+        if (size > 0) {
+            int firstResult = Math.max(page, 0) * size;
+            query.setFirstResult(firstResult);
+            query.setMaxResults(size);
+        }
+
+        return query.getResultList();
+    }
+
+    @Transactional
+    public Product save(Product product) {
+        if (product.getId() == null) {
+            entityManager.persist(product);
+            return product;
+        }
+        return entityManager.merge(product);
+    }
+
+    @Transactional
+    public void delete(Product product) {
+        Product managed = product;
+        if (!entityManager.contains(product)) {
+            managed = entityManager.merge(product);
+        }
+        entityManager.remove(managed);
+    }
+}

--- a/veristore/src/main/java/com/theplutushome/veristore/repo/ProductRepo.java
+++ b/veristore/src/main/java/com/theplutushome/veristore/repo/ProductRepo.java
@@ -41,22 +41,8 @@ public class ProductRepo {
         CriteriaQuery<Product> cq = cb.createQuery(Product.class);
         Root<Product> root = cq.from(Product.class);
 
-        List<Predicate> predicates = new ArrayList<>();
-        predicates.add(cb.isTrue(root.get("active")));
-
-        if (country != null && !country.isBlank()) {
-            predicates.add(cb.equal(cb.lower(root.get("country")), country.toLowerCase()));
-        }
-
-        if (category != null && !category.isBlank()) {
-            predicates.add(cb.equal(cb.lower(root.get("category")), category.toLowerCase()));
-        }
-
-        if (maxPriceMinor != null) {
-            predicates.add(cb.lessThanOrEqualTo(root.get("priceMinor"), maxPriceMinor));
-        }
-
-        cq.select(root).where(predicates.toArray(new Predicate[0])).orderBy(cb.asc(root.get("name")));
+        Predicate[] filters = buildFilters(cb, root, country, category, maxPriceMinor);
+        cq.select(root).where(filters).orderBy(cb.asc(root.get("name")));
 
         TypedQuery<Product> query = entityManager.createQuery(cq);
         if (size > 0) {
@@ -66,6 +52,15 @@ public class ProductRepo {
         }
 
         return query.getResultList();
+    }
+
+    public long countSearch(String country, String category, Long maxPriceMinor) {
+        CriteriaBuilder cb = entityManager.getCriteriaBuilder();
+        CriteriaQuery<Long> cq = cb.createQuery(Long.class);
+        Root<Product> root = cq.from(Product.class);
+        Predicate[] filters = buildFilters(cb, root, country, category, maxPriceMinor);
+        cq.select(cb.count(root)).where(filters);
+        return entityManager.createQuery(cq).getSingleResult();
     }
 
     @Transactional
@@ -84,5 +79,24 @@ public class ProductRepo {
             managed = entityManager.merge(product);
         }
         entityManager.remove(managed);
+    }
+
+    private Predicate[] buildFilters(CriteriaBuilder cb, Root<Product> root, String country, String category,
+            Long maxPriceMinor) {
+        List<Predicate> predicates = new ArrayList<>();
+        predicates.add(cb.isTrue(root.get("active")));
+
+        if (country != null && !country.isBlank()) {
+            predicates.add(cb.equal(cb.lower(root.get("country")), country.toLowerCase()));
+        }
+
+        if (category != null && !category.isBlank()) {
+            predicates.add(cb.equal(cb.lower(root.get("category")), category.toLowerCase()));
+        }
+
+        if (maxPriceMinor != null) {
+            predicates.add(cb.lessThanOrEqualTo(root.get("priceMinor"), maxPriceMinor));
+        }
+        return predicates.toArray(new Predicate[0]);
     }
 }

--- a/veristore/src/main/java/com/theplutushome/veristore/repo/SecretCodeRepo.java
+++ b/veristore/src/main/java/com/theplutushome/veristore/repo/SecretCodeRepo.java
@@ -1,0 +1,47 @@
+package com.theplutushome.veristore.repo;
+
+import java.util.List;
+import java.util.Optional;
+
+import com.theplutushome.veristore.entity.SecretCode;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import jakarta.transaction.Transactional;
+
+@ApplicationScoped
+public class SecretCodeRepo {
+
+    @PersistenceContext
+    EntityManager entityManager;
+
+    public Optional<SecretCode> findById(Long id) {
+        return Optional.ofNullable(entityManager.find(SecretCode.class, id));
+    }
+
+    public List<SecretCode> findByOrderId(Long orderId) {
+        return entityManager.createQuery(
+                        "SELECT sc FROM SecretCode sc WHERE sc.orderId = :orderId ORDER BY sc.createdAt", SecretCode.class)
+                .setParameter("orderId", orderId)
+                .getResultList();
+    }
+
+    @Transactional
+    public SecretCode save(SecretCode secretCode) {
+        if (secretCode.getId() == null) {
+            entityManager.persist(secretCode);
+            return secretCode;
+        }
+        return entityManager.merge(secretCode);
+    }
+
+    @Transactional
+    public void delete(SecretCode secretCode) {
+        SecretCode managed = secretCode;
+        if (!entityManager.contains(secretCode)) {
+            managed = entityManager.merge(secretCode);
+        }
+        entityManager.remove(managed);
+    }
+}

--- a/veristore/src/main/java/com/theplutushome/veristore/repo/package-info.java
+++ b/veristore/src/main/java/com/theplutushome/veristore/repo/package-info.java
@@ -1,0 +1,1 @@
+package com.theplutushome.veristore.$pkg;

--- a/veristore/src/main/java/com/theplutushome/veristore/service/package-info.java
+++ b/veristore/src/main/java/com/theplutushome/veristore/service/package-info.java
@@ -1,0 +1,1 @@
+package com.theplutushome.veristore.$pkg;

--- a/veristore/src/main/java/com/theplutushome/veristore/util/Masker.java
+++ b/veristore/src/main/java/com/theplutushome/veristore/util/Masker.java
@@ -1,0 +1,22 @@
+package com.theplutushome.veristore.util;
+
+public final class Masker {
+
+    private Masker() {
+    }
+
+    public static String mask(String value) {
+        if (value == null || value.isBlank()) {
+            return "";
+        }
+        String trimmed = value.trim();
+        int length = trimmed.length();
+        if (length <= 4) {
+            return "*".repeat(length);
+        }
+        int visible = Math.min(4, length);
+        String visiblePart = trimmed.substring(length - visible);
+        String masked = "*".repeat(length - visible);
+        return masked + visiblePart;
+    }
+}

--- a/veristore/src/main/java/com/theplutushome/veristore/util/package-info.java
+++ b/veristore/src/main/java/com/theplutushome/veristore/util/package-info.java
@@ -1,0 +1,1 @@
+package com.theplutushome.veristore.$pkg;

--- a/veristore/src/main/java/com/theplutushome/veristore/view/CartView.java
+++ b/veristore/src/main/java/com/theplutushome/veristore/view/CartView.java
@@ -1,0 +1,151 @@
+package com.theplutushome.veristore.view;
+
+import java.io.Serial;
+import java.io.Serializable;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import com.theplutushome.veristore.dto.CartLineDTO;
+import com.theplutushome.veristore.entity.Product;
+
+import jakarta.enterprise.context.SessionScoped;
+import jakarta.faces.application.FacesMessage;
+import jakarta.faces.context.FacesContext;
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
+
+@Named
+@SessionScoped
+public class CartView implements Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
+
+    private final List<CartLineDTO> lines = new ArrayList<>();
+
+    @Inject
+    GlobalView globalView;
+
+    public List<CartLineDTO> getLines() {
+        return lines;
+    }
+
+    public void add(Product product, int qty) {
+        if (product == null || qty <= 0) {
+            return;
+        }
+        CartLineDTO line = findLine(product.getSku());
+        if (line == null) {
+            line = new CartLineDTO();
+            line.setSku(product.getSku());
+            line.setName(product.getName());
+            line.setCurrency(Optional.ofNullable(product.getCurrency()).orElse(globalView.getCurrency()));
+            line.setUnitPriceMinor(product.getPriceMinor());
+            lines.add(line);
+        }
+        line.setQty(Math.max(1, line.getQty() + qty));
+        refreshLine(line);
+        FacesContext facesContext = FacesContext.getCurrentInstance();
+        if (facesContext != null) {
+            facesContext.addMessage(null,
+                    new FacesMessage(FacesMessage.SEVERITY_INFO, "Added to cart", product.getName() + " x" + line.getQty()));
+        }
+    }
+
+    public void update(CartLineDTO updatedLine) {
+        if (updatedLine == null) {
+            return;
+        }
+        CartLineDTO existing = findLine(updatedLine.getSku());
+        if (existing == null) {
+            return;
+        }
+        int newQty = Math.max(0, updatedLine.getQty());
+        if (newQty == 0) {
+            remove(existing);
+            return;
+        }
+        existing.setQty(newQty);
+        refreshLine(existing);
+    }
+
+    public void remove(CartLineDTO line) {
+        if (line == null) {
+            return;
+        }
+        lines.removeIf(existing -> existing.getSku().equalsIgnoreCase(line.getSku()));
+    }
+
+    public void empty() {
+        lines.clear();
+    }
+
+    public void recalculate() {
+        lines.removeIf(line -> line.getQty() <= 0);
+        lines.forEach(line -> {
+            line.setQty(Math.max(1, line.getQty()));
+            refreshLine(line);
+        });
+    }
+
+    public long subtotal() {
+        return lines.stream().mapToLong(CartLineDTO::getTotalMinor).sum();
+    }
+
+    public long fees() {
+        long subtotalMinor = subtotal();
+        if (subtotalMinor <= 0) {
+            return 0;
+        }
+        return BigDecimal.valueOf(subtotalMinor)
+                .multiply(BigDecimal.valueOf(5))
+                .divide(BigDecimal.valueOf(100), 0, RoundingMode.HALF_UP)
+                .longValue();
+    }
+
+    public long total() {
+        return subtotal() + fees();
+    }
+
+    public String subtotalFormatted() {
+        return globalView.formatMoney(subtotal(), getCurrencyCode());
+    }
+
+    public String feesFormatted() {
+        return globalView.formatMoney(fees(), getCurrencyCode());
+    }
+
+    public String totalFormatted() {
+        return globalView.formatMoney(total(), getCurrencyCode());
+    }
+
+    public String getCurrencyCode() {
+        if (lines.isEmpty()) {
+            return globalView.getCurrency();
+        }
+        return Optional.ofNullable(lines.get(0).getCurrency()).orElse(globalView.getCurrency());
+    }
+
+    private CartLineDTO findLine(String sku) {
+        if (sku == null) {
+            return null;
+        }
+        return lines.stream()
+                .filter(line -> sku.equalsIgnoreCase(line.getSku()))
+                .findFirst()
+                .orElse(null);
+    }
+
+    private void refreshLine(CartLineDTO line) {
+        if (line.getCurrency() == null || line.getCurrency().isBlank()) {
+            line.setCurrency(globalView.getCurrency());
+        }
+        long totalMinor = line.getUnitPriceMinor() * line.getQty();
+        line.setTotalMinor(totalMinor);
+        line.setPriceFormatted(globalView.formatMoney(line.getUnitPriceMinor(), line.getCurrency()));
+        line.setTotalFormatted(globalView.formatMoney(totalMinor, line.getCurrency()));
+    }
+}

--- a/veristore/src/main/java/com/theplutushome/veristore/view/CheckoutView.java
+++ b/veristore/src/main/java/com/theplutushome/veristore/view/CheckoutView.java
@@ -1,0 +1,163 @@
+package com.theplutushome.veristore.view;
+
+import java.io.Serial;
+import java.io.Serializable;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+
+import com.theplutushome.veristore.dto.CartLineDTO;
+import com.theplutushome.veristore.payment.PaymentService;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.faces.application.FacesMessage;
+import jakarta.faces.context.FacesContext;
+import jakarta.faces.view.ViewScoped;
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
+
+@Named
+@ViewScoped
+public class CheckoutView implements Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
+
+    private String email;
+    private String phone;
+    private boolean deliverByEmail = true;
+    private boolean deliverBySms;
+    private List<CartLineDTO> lines = new ArrayList<>();
+    private long subtotalMinor;
+    private long feesMinor;
+    private long totalMinor;
+    private String currency;
+    private URI paymentRedirect;
+    private boolean showStatusPanel;
+    private String paymentStatus;
+
+    @Inject
+    PaymentService paymentService;
+
+    @Inject
+    CartView cartView;
+
+    @Inject
+    GlobalView globalView;
+
+    @PostConstruct
+    public void init() {
+        snapshotCart();
+    }
+
+    public void pay() {
+        snapshotCart();
+        if (lines.isEmpty()) {
+            addMessage(FacesMessage.SEVERITY_WARN, "Your cart is empty", "Add items before paying.");
+            return;
+        }
+        paymentRedirect = paymentService.createInvoiceAndRedirect(totalMinor, currency);
+        paymentStatus = "Payment initiated. Follow the redirect to complete checkout.";
+        showStatusPanel = true;
+    }
+
+    public void handlePaymentReturn(String status) {
+        paymentStatus = status;
+        showStatusPanel = true;
+        if (status != null && status.toLowerCase().contains("success")) {
+            addMessage(FacesMessage.SEVERITY_INFO, "Payment confirmed", null);
+            cartView.empty();
+            snapshotCart();
+        }
+    }
+
+    public void cancel() {
+        cartView.empty();
+        snapshotCart();
+        paymentStatus = null;
+        showStatusPanel = false;
+    }
+
+    public List<CartLineDTO> getLines() {
+        return lines;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public String getPhone() {
+        return phone;
+    }
+
+    public void setPhone(String phone) {
+        this.phone = phone;
+    }
+
+    public boolean isDeliverByEmail() {
+        return deliverByEmail;
+    }
+
+    public void setDeliverByEmail(boolean deliverByEmail) {
+        this.deliverByEmail = deliverByEmail;
+    }
+
+    public boolean isDeliverBySms() {
+        return deliverBySms;
+    }
+
+    public void setDeliverBySms(boolean deliverBySms) {
+        this.deliverBySms = deliverBySms;
+    }
+
+    public long getTotalMinor() {
+        return totalMinor;
+    }
+
+    public String getCurrency() {
+        return currency;
+    }
+
+    public URI getPaymentRedirect() {
+        return paymentRedirect;
+    }
+
+    public boolean isShowStatusPanel() {
+        return showStatusPanel;
+    }
+
+    public String getPaymentStatus() {
+        return paymentStatus;
+    }
+
+    public String getSubtotalFormatted() {
+        return globalView.formatMoney(subtotalMinor, currency);
+    }
+
+    public String getFeesFormatted() {
+        return globalView.formatMoney(feesMinor, currency);
+    }
+
+    public String getTotalFormatted() {
+        return globalView.formatMoney(totalMinor, currency);
+    }
+
+    private void snapshotCart() {
+        lines = cartView.getLines().stream().map(CartLineDTO::new).toList();
+        subtotalMinor = lines.stream().mapToLong(CartLineDTO::getTotalMinor).sum();
+        feesMinor = cartView.fees();
+        totalMinor = subtotalMinor + feesMinor;
+        currency = cartView.getCurrencyCode();
+    }
+
+    private void addMessage(FacesMessage.Severity severity, String summary, String detail) {
+        FacesContext context = FacesContext.getCurrentInstance();
+        if (context != null) {
+            context.addMessage(null, new FacesMessage(severity, summary, detail));
+        }
+    }
+}

--- a/veristore/src/main/java/com/theplutushome/veristore/view/GlobalView.java
+++ b/veristore/src/main/java/com/theplutushome/veristore/view/GlobalView.java
@@ -1,0 +1,112 @@
+package com.theplutushome.veristore.view;
+
+import java.io.Serial;
+import java.io.Serializable;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.text.NumberFormat;
+import java.util.Currency;
+import java.util.Locale;
+import java.util.Optional;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.enterprise.context.SessionScoped;
+import jakarta.faces.context.FacesContext;
+import jakarta.inject.Named;
+
+@Named
+@SessionScoped
+public class GlobalView implements Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
+
+    private String localeCode = "en";
+    private String currency = "USD";
+    private boolean rtl;
+
+    @PostConstruct
+    public void init() {
+        updateLocaleState();
+        applyLocaleToViewRoot();
+    }
+
+    public String getLocaleCode() {
+        return localeCode;
+    }
+
+    public void setLocaleCode(String localeCode) {
+        this.localeCode = Optional.ofNullable(localeCode).filter(code -> !code.isBlank()).orElse("en");
+        updateLocaleState();
+        applyLocaleToViewRoot();
+    }
+
+    public String getCurrency() {
+        return currency;
+    }
+
+    public void setCurrency(String currency) {
+        this.currency = normalizeCurrency(currency);
+    }
+
+    public boolean isRtl() {
+        return rtl;
+    }
+
+    public Locale getLocale() {
+        return Locale.forLanguageTag(localeCode);
+    }
+
+    public void changeLocale() {
+        updateLocaleState();
+        applyLocaleToViewRoot();
+    }
+
+    public void changeCurrency() {
+        this.currency = normalizeCurrency(this.currency);
+    }
+
+    public String formatMoney(long amountMinor, String currencyCode) {
+        Currency resolvedCurrency = resolveCurrency(currencyCode);
+        int fractionDigits = Math.max(resolvedCurrency.getDefaultFractionDigits(), 0);
+        BigDecimal amount = BigDecimal.valueOf(amountMinor, fractionDigits);
+        NumberFormat format = NumberFormat.getCurrencyInstance(getLocale());
+        format.setCurrency(resolvedCurrency);
+        format.setMinimumFractionDigits(fractionDigits);
+        format.setMaximumFractionDigits(fractionDigits);
+        return format.format(amount.setScale(fractionDigits, RoundingMode.HALF_UP));
+    }
+
+    private void updateLocaleState() {
+        rtl = "ar".equalsIgnoreCase(localeCode) || localeCode.toLowerCase(Locale.ROOT).startsWith("ar-");
+    }
+
+    private void applyLocaleToViewRoot() {
+        FacesContext facesContext = FacesContext.getCurrentInstance();
+        if (facesContext != null && facesContext.getViewRoot() != null) {
+            facesContext.getViewRoot().setLocale(getLocale());
+        }
+    }
+
+    private String normalizeCurrency(String currencyCode) {
+        try {
+            return Currency.getInstance(Optional.ofNullable(currencyCode).filter(code -> !code.isBlank()).orElse(this.currency)).getCurrencyCode();
+        } catch (IllegalArgumentException ex) {
+            return "USD";
+        }
+    }
+
+    private Currency resolveCurrency(String currencyCode) {
+        try {
+            if (currencyCode != null && !currencyCode.isBlank()) {
+                return Currency.getInstance(currencyCode);
+            }
+        } catch (IllegalArgumentException ignored) {
+        }
+        try {
+            return Currency.getInstance(this.currency);
+        } catch (IllegalArgumentException ex) {
+            return Currency.getInstance("USD");
+        }
+    }
+}

--- a/veristore/src/main/java/com/theplutushome/veristore/view/OrderView.java
+++ b/veristore/src/main/java/com/theplutushome/veristore/view/OrderView.java
@@ -1,0 +1,86 @@
+package com.theplutushome.veristore.view;
+
+import java.io.Serial;
+import java.io.Serializable;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import com.theplutushome.veristore.entity.Order;
+import com.theplutushome.veristore.entity.SecretCode;
+import com.theplutushome.veristore.repo.OrderRepo;
+import com.theplutushome.veristore.repo.SecretCodeRepo;
+import com.theplutushome.veristore.util.Masker;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.faces.application.FacesMessage;
+import jakarta.faces.context.FacesContext;
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
+
+@Named
+@RequestScoped
+public class OrderView implements Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
+
+    private Order order;
+    private List<SecretCode> codes = Collections.emptyList();
+
+    @Inject
+    OrderRepo orderRepo;
+
+    @Inject
+    SecretCodeRepo secretCodeRepo;
+
+    @PostConstruct
+    public void init() {
+        FacesContext facesContext = FacesContext.getCurrentInstance();
+        if (facesContext == null) {
+            return;
+        }
+        Map<String, String> params = facesContext.getExternalContext().getRequestParameterMap();
+        String publicId = params.getOrDefault("order", params.get("publicId"));
+        if (publicId == null || publicId.isBlank()) {
+            return;
+        }
+        orderRepo.findByPublicId(publicId).ifPresent(found -> {
+            order = found;
+            codes = secretCodeRepo.findByOrderId(found.getId());
+        });
+    }
+
+    public List<String> maskedCodes() {
+        return codes.stream()
+                .map(SecretCode::getCode)
+                .filter(code -> code != null && !code.isBlank())
+                .map(Masker::mask)
+                .collect(Collectors.toList());
+    }
+
+    public void resendEmail() {
+        addMessage(FacesMessage.SEVERITY_INFO, "Email scheduled", "We will resend your codes shortly.");
+    }
+
+    public void resendSms() {
+        addMessage(FacesMessage.SEVERITY_INFO, "SMS scheduled", "Text delivery will retry within a few minutes.");
+    }
+
+    public Order getOrder() {
+        return order;
+    }
+
+    public boolean isLoaded() {
+        return order != null;
+    }
+
+    private void addMessage(FacesMessage.Severity severity, String summary, String detail) {
+        FacesContext context = FacesContext.getCurrentInstance();
+        if (context != null) {
+            context.addMessage(null, new FacesMessage(severity, summary, detail));
+        }
+    }
+}

--- a/veristore/src/main/java/com/theplutushome/veristore/view/ProductDetailView.java
+++ b/veristore/src/main/java/com/theplutushome/veristore/view/ProductDetailView.java
@@ -1,0 +1,105 @@
+package com.theplutushome.veristore.view;
+
+import java.io.Serial;
+import java.io.Serializable;
+import java.util.Optional;
+
+import com.theplutushome.veristore.dto.ProductDetailDTO;
+import com.theplutushome.veristore.entity.Product;
+import com.theplutushome.veristore.repo.ProductRepo;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.faces.application.FacesMessage;
+import jakarta.faces.context.FacesContext;
+import jakarta.faces.view.ViewScoped;
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
+
+@Named
+@ViewScoped
+public class ProductDetailView implements Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
+
+    private ProductDetailDTO item;
+    private Product product;
+    private int qty = 1;
+    private boolean acceptedTos;
+
+    @Inject
+    ProductRepo productRepo;
+
+    @Inject
+    CartView cartView;
+
+    @Inject
+    GlobalView globalView;
+
+    @PostConstruct
+    public void init() {
+        FacesContext facesContext = FacesContext.getCurrentInstance();
+        if (facesContext == null) {
+            return;
+        }
+        String sku = facesContext.getExternalContext().getRequestParameterMap().getOrDefault("sku", "");
+        if (sku.isBlank()) {
+            return;
+        }
+        productRepo.findBySku(sku).ifPresent(this::loadProduct);
+    }
+
+    public void addToCart() {
+        if (product == null) {
+            return;
+        }
+        FacesContext facesContext = FacesContext.getCurrentInstance();
+        if (!acceptedTos) {
+            if (facesContext != null) {
+                facesContext.addMessage(null, new FacesMessage(FacesMessage.SEVERITY_WARN,
+                        "Please accept the terms to continue", null));
+            }
+            return;
+        }
+        int quantity = Math.max(1, qty);
+        cartView.add(product, quantity);
+        qty = 1;
+        acceptedTos = false;
+    }
+
+    public ProductDetailDTO getItem() {
+        return item;
+    }
+
+    public int getQty() {
+        return qty;
+    }
+
+    public void setQty(int qty) {
+        this.qty = qty;
+    }
+
+    public boolean isAcceptedTos() {
+        return acceptedTos;
+    }
+
+    public void setAcceptedTos(boolean acceptedTos) {
+        this.acceptedTos = acceptedTos;
+    }
+
+    private void loadProduct(Product found) {
+        this.product = found;
+        ProductDetailDTO dto = new ProductDetailDTO();
+        dto.setId(found.getId());
+        dto.setSku(found.getSku());
+        dto.setName(found.getName());
+        dto.setShortDesc(Optional.ofNullable(found.getShortDesc()).orElse(""));
+        dto.setLongDesc(Optional.ofNullable(found.getLongDesc()).orElse(""));
+        dto.setCountry(Optional.ofNullable(found.getCountry()).orElse(""));
+        dto.setCategory(Optional.ofNullable(found.getCategory()).orElse(""));
+        dto.setImageUrl(Optional.ofNullable(found.getImageUrl()).orElse(found.getThumbnailUrl()));
+        dto.setCurrency(Optional.ofNullable(found.getCurrency()).orElse(globalView.getCurrency()));
+        dto.setPriceFormatted(globalView.formatMoney(found.getPriceMinor(), dto.getCurrency()));
+        this.item = dto;
+    }
+}

--- a/veristore/src/main/java/com/theplutushome/veristore/view/ProductView.java
+++ b/veristore/src/main/java/com/theplutushome/veristore/view/ProductView.java
@@ -1,0 +1,167 @@
+package com.theplutushome.veristore.view;
+
+import java.io.Serial;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import com.theplutushome.veristore.dto.ProductCardDTO;
+import com.theplutushome.veristore.entity.Product;
+import com.theplutushome.veristore.repo.ProductRepo;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.faces.view.ViewScoped;
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
+
+@Named
+@ViewScoped
+public class ProductView implements Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
+
+    private final List<ProductCardDTO> items = new ArrayList<>();
+    private String country;
+    private String category;
+    private String maxPrice;
+    private int page;
+    private final int size = 12;
+    private int pages;
+    private boolean hasPrev;
+    private boolean hasNext;
+
+    @Inject
+    ProductRepo productRepo;
+
+    @Inject
+    GlobalView globalView;
+
+    @PostConstruct
+    public void init() {
+        loadItems();
+    }
+
+    public void applyFilters() {
+        page = 0;
+        loadItems();
+    }
+
+    public void next() {
+        if (hasNext) {
+            page++;
+            loadItems();
+        }
+    }
+
+    public void prev() {
+        if (hasPrev) {
+            page--;
+            loadItems();
+        }
+    }
+
+    public List<ProductCardDTO> getItems() {
+        return items;
+    }
+
+    public String getCountry() {
+        return country;
+    }
+
+    public void setCountry(String country) {
+        this.country = country;
+    }
+
+    public String getCategory() {
+        return category;
+    }
+
+    public void setCategory(String category) {
+        this.category = category;
+    }
+
+    public String getMaxPrice() {
+        return maxPrice;
+    }
+
+    public void setMaxPrice(String maxPrice) {
+        this.maxPrice = maxPrice;
+    }
+
+    public int getPage() {
+        return page;
+    }
+
+    public int getSize() {
+        return size;
+    }
+
+    public int getPages() {
+        return pages;
+    }
+
+    public boolean isHasPrev() {
+        return hasPrev;
+    }
+
+    public boolean isHasNext() {
+        return hasNext;
+    }
+
+    private void loadItems() {
+        Long maxPriceMinor = parseMaxPrice();
+        long total = productRepo.countSearch(country, category, maxPriceMinor);
+        pages = size > 0 ? (int) Math.ceil(total / (double) size) : 0;
+        if (pages > 0 && page >= pages) {
+            page = pages - 1;
+        }
+        if (pages == 0) {
+            page = 0;
+        }
+        items.clear();
+        for (Product product : productRepo.search(country, category, maxPriceMinor, page, size)) {
+            items.add(toCard(product));
+        }
+        hasPrev = page > 0;
+        hasNext = pages > 0 && (page + 1) < pages;
+    }
+
+    private Long parseMaxPrice() {
+        if (maxPrice == null || maxPrice.isBlank()) {
+            return null;
+        }
+        try {
+            String normalized = maxPrice.replace(",", ".");
+            if (normalized.contains(".")) {
+                String[] parts = normalized.split("\\.", 2);
+                long whole = Long.parseLong(parts[0].isBlank() ? "0" : parts[0]);
+                String fractionPart = parts.length > 1 ? parts[1] : "";
+                fractionPart = (fractionPart + "00").substring(0, 2);
+                long fraction = Long.parseLong(fractionPart);
+                long minor = whole * 100 + fraction;
+                return minor < 0 ? null : minor;
+            }
+            long minor = Long.parseLong(normalized) * 100;
+            return minor < 0 ? null : minor;
+        } catch (NumberFormatException ex) {
+            return null;
+        }
+    }
+
+    private ProductCardDTO toCard(Product product) {
+        ProductCardDTO dto = new ProductCardDTO();
+        dto.setId(product.getId());
+        dto.setSku(product.getSku());
+        dto.setName(product.getName());
+        dto.setShortDesc(Optional.ofNullable(product.getShortDesc()).orElse(""));
+        dto.setCountry(Optional.ofNullable(product.getCountry()).orElse(""));
+        dto.setCategory(Optional.ofNullable(product.getCategory()).orElse(""));
+        dto.setThumbnailUrl(Optional.ofNullable(product.getThumbnailUrl())
+                .filter(value -> !value.isBlank())
+                .orElse(Optional.ofNullable(product.getImageUrl()).orElse("")));
+        dto.setPriceFormatted(globalView.formatMoney(product.getPriceMinor(), product.getCurrency()));
+        return dto;
+    }
+}

--- a/veristore/src/main/java/com/theplutushome/veristore/view/package-info.java
+++ b/veristore/src/main/java/com/theplutushome/veristore/view/package-info.java
@@ -1,0 +1,1 @@
+package com.theplutushome.veristore.$pkg;

--- a/veristore/src/main/resources/META-INF/persistence.xml
+++ b/veristore/src/main/resources/META-INF/persistence.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<persistence xmlns="https://jakarta.ee/xml/ns/persistence"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="https://jakarta.ee/xml/ns/persistence https://jakarta.ee/xml/ns/persistence/persistence_3_0.xsd"
+             version="3.0">
+    <persistence-unit name="veristorePU" transaction-type="RESOURCE_LOCAL">
+        <provider>org.hibernate.jpa.HibernatePersistenceProvider</provider>
+        <properties>
+            <property name="jakarta.persistence.jdbc.driver" value="org.h2.Driver"/>
+            <property name="jakarta.persistence.jdbc.url" value="jdbc:h2:mem:veristore;DB_CLOSE_DELAY=-1"/>
+            <property name="jakarta.persistence.jdbc.user" value="sa"/>
+            <property name="jakarta.persistence.jdbc.password" value=""/>
+            <property name="hibernate.hbm2ddl.auto" value="create-drop"/>
+            <property name="hibernate.show_sql" value="${hibernate.show_sql}"/>
+            <property name="hibernate.format_sql" value="true"/>
+        </properties>
+    </persistence-unit>
+</persistence>

--- a/veristore/src/main/webapp/WEB-INF/partials/footer.xhtml
+++ b/veristore/src/main/webapp/WEB-INF/partials/footer.xhtml
@@ -1,0 +1,26 @@
+<ui:composition xmlns="http://www.w3.org/1999/xhtml"
+                xmlns:h="http://xmlns.jcp.org/jsf/html"
+                xmlns:ui="http://xmlns.jcp.org/jsf/facelets">
+    <footer class="bg-dark text-light py-4 mt-auto" aria-label="Footer">
+        <div class="container d-flex flex-column flex-lg-row justify-content-between gap-4">
+            <div>
+                <h2 class="h5 mb-2">Veristore</h2>
+                <p class="mb-0 small">Trusted commerce for digital, physical, and hybrid fulfillment.</p>
+            </div>
+            <div>
+                <h3 class="h6 text-uppercase small">Support</h3>
+                <ul class="list-unstyled mb-0 small">
+                    <li><a class="link-light" href="mailto:support@veristore.com">support@veristore.com</a></li>
+                    <li><span>+1 (555) 010-2000</span></li>
+                </ul>
+            </div>
+            <nav aria-label="Legal" class="small">
+                <h3 class="h6 text-uppercase">Resources</h3>
+                <ul class="list-unstyled mb-0">
+                    <li><h:link outcome="/products" styleClass="link-light">Product catalog</h:link></li>
+                    <li><h:link outcome="/checkout" styleClass="link-light">Checkout</h:link></li>
+                </ul>
+            </nav>
+        </div>
+    </footer>
+</ui:composition>

--- a/veristore/src/main/webapp/WEB-INF/partials/navbar.xhtml
+++ b/veristore/src/main/webapp/WEB-INF/partials/navbar.xhtml
@@ -1,0 +1,31 @@
+<ui:composition xmlns="http://www.w3.org/1999/xhtml"
+                xmlns:h="http://xmlns.jcp.org/jsf/html"
+                xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+                xmlns:pt="http://xmlns.jcp.org/jsf/passthrough">
+    <nav class="navbar navbar-expand-lg navbar-dark bg-primary shadow-sm" aria-label="Primary">
+        <div class="container py-2">
+            <h:link outcome="/index" styleClass="navbar-brand d-flex align-items-center gap-2">
+                <span class="fw-bold fs-4">Veristore</span>
+            </h:link>
+            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#mainNav" aria-controls="mainNav" aria-expanded="false" aria-label="Toggle navigation">
+                <span class="navbar-toggler-icon"></span>
+            </button>
+            <div class="collapse navbar-collapse" id="mainNav">
+                <ul class="navbar-nav ms-auto mb-2 mb-lg-0 gap-lg-2">
+                    <li class="nav-item">
+                        <h:link outcome="/products" styleClass="nav-link">Products</h:link>
+                    </li>
+                    <li class="nav-item">
+                        <h:link outcome="/cart" styleClass="nav-link">Cart</h:link>
+                    </li>
+                    <li class="nav-item">
+                        <h:link outcome="/checkout" styleClass="nav-link">Checkout</h:link>
+                    </li>
+                    <li class="nav-item">
+                        <h:link outcome="/order-success" styleClass="nav-link">Order status</h:link>
+                    </li>
+                </ul>
+            </div>
+        </div>
+    </nav>
+</ui:composition>

--- a/veristore/src/main/webapp/WEB-INF/template.xhtml
+++ b/veristore/src/main/webapp/WEB-INF/template.xhtml
@@ -4,6 +4,7 @@
                 xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
                 xmlns:f="http://xmlns.jcp.org/jsf/core"
                 xmlns:pt="http://xmlns.jcp.org/jsf/passthrough">
+    <f:view locale="#{globalView.locale}">
     <h:head>
         <meta charset="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -11,7 +12,8 @@
         <h:outputStylesheet library="bootstrap" name="css/bootstrap.min.css" />
         <ui:insert name="styles" />
     </h:head>
-    <h:body class="d-flex flex-column min-vh-100 bg-light text-body">
+    <h:body class="d-flex flex-column min-vh-100 bg-light text-body"
+            dir="#{globalView.rtl ? 'rtl' : 'ltr'}" pt:lang="#{globalView.localeCode}">
         <a href="#main" class="visually-hidden-focusable position-absolute top-0 start-0 m-3 px-3 py-2 bg-dark text-light rounded">Skip to main content</a>
         <ui:include src="/WEB-INF/partials/navbar.xhtml" />
 
@@ -64,4 +66,5 @@
         </h:outputScript>
         <ui:insert name="scripts" />
     </h:body>
+    </f:view>
 </ui:composition>

--- a/veristore/src/main/webapp/WEB-INF/template.xhtml
+++ b/veristore/src/main/webapp/WEB-INF/template.xhtml
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<ui:composition xmlns="http://www.w3.org/1999/xhtml"
+                xmlns:h="http://xmlns.jcp.org/jsf/html"
+                xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+                xmlns:f="http://xmlns.jcp.org/jsf/core"
+                xmlns:pt="http://xmlns.jcp.org/jsf/passthrough">
+    <h:head>
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <title><ui:insert name="title">Veristore</ui:insert></title>
+        <h:outputStylesheet library="bootstrap" name="css/bootstrap.min.css" />
+        <ui:insert name="styles" />
+    </h:head>
+    <h:body class="d-flex flex-column min-vh-100 bg-light text-body">
+        <a href="#main" class="visually-hidden-focusable position-absolute top-0 start-0 m-3 px-3 py-2 bg-dark text-light rounded">Skip to main content</a>
+        <ui:include src="/WEB-INF/partials/navbar.xhtml" />
+
+        <main id="main" class="flex-grow-1">
+            <div class="container py-4 py-lg-5">
+                <h:panelGroup layout="block"
+                              rendered="#{not empty facesContext.messageList}"
+                              styleClass="mb-4"
+                              pt:aria-live="polite"
+                              pt:aria-atomic="true">
+                    <h:messages id="globalMessages"
+                                showSummary="true"
+                                showDetail="true"
+                                layout="list"
+                                styleClass="list-unstyled d-flex flex-column gap-3 mb-0"
+                                infoClass="alert alert-info alert-dismissible fade show mb-0"
+                                warnClass="alert alert-warning alert-dismissible fade show mb-0"
+                                errorClass="alert alert-danger alert-dismissible fade show mb-0"
+                                fatalClass="alert alert-danger alert-dismissible fade show mb-0"
+                                pt:role="alert" />
+                </h:panelGroup>
+                <ui:insert name="content" />
+            </div>
+        </main>
+
+        <ui:include src="/WEB-INF/partials/footer.xhtml" />
+
+        <h:outputScript library="bootstrap" name="js/bootstrap.bundle.min.js" target="body" />
+        <h:outputScript target="body">
+//<![CDATA[
+(function () {
+    var messageList = document.getElementById('globalMessages');
+    if (!messageList) {
+        return;
+    }
+    messageList.querySelectorAll('li.alert-dismissible').forEach(function (item) {
+        item.setAttribute('role', 'alert');
+        if (item.querySelector('[data-bs-dismiss="alert"]')) {
+            return;
+        }
+        var button = document.createElement('button');
+        button.type = 'button';
+        button.className = 'btn-close';
+        button.setAttribute('data-bs-dismiss', 'alert');
+        button.setAttribute('aria-label', 'Dismiss message');
+        item.appendChild(button);
+    });
+})();
+//]]>
+        </h:outputScript>
+        <ui:insert name="scripts" />
+    </h:body>
+</ui:composition>

--- a/veristore/src/main/webapp/cart.xhtml
+++ b/veristore/src/main/webapp/cart.xhtml
@@ -1,0 +1,82 @@
+<!DOCTYPE html>
+<ui:composition xmlns="http://www.w3.org/1999/xhtml"
+                xmlns:h="http://xmlns.jcp.org/jsf/html"
+                xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+                template="/WEB-INF/template.xhtml">
+    <ui:define name="title">Cart &ndash; Veristore</ui:define>
+    <ui:define name="content">
+        <h1 class="h2 mb-4">Shopping cart</h1>
+        <h:form id="cartForm" class="row g-4">
+            <div class="col-12 col-lg-8">
+                <div class="table-responsive">
+                    <table class="table align-middle">
+                        <caption class="text-muted">Adjust quantities or remove items before continuing to checkout.</caption>
+                        <thead>
+                            <tr>
+                                <th scope="col">Item</th>
+                                <th scope="col" class="text-center">Price</th>
+                                <th scope="col" class="text-center">Quantity</th>
+                                <th scope="col" class="text-end">Subtotal</th>
+                                <th scope="col" class="text-end">Actions</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr>
+                                <td>
+                                    <p class="fw-semibold mb-1">Veristore Enterprise Toolkit</p>
+                                    <p class="mb-0 text-muted small">Instant digital delivery &middot; SKU VST-ENT-993</p>
+                                </td>
+                                <td class="text-center">$799</td>
+                                <td class="text-center" style="min-width: 7rem;">
+                                    <h:inputText styleClass="form-control form-control-sm text-center" aria-label="Toolkit quantity" />
+                                </td>
+                                <td class="text-end">$1,598</td>
+                                <td class="text-end">
+                                    <h:commandLink value="Remove" styleClass="btn btn-link text-danger p-0" />
+                                </td>
+                            </tr>
+                            <tr>
+                                <td>
+                                    <p class="fw-semibold mb-1">Creator Starter Pack</p>
+                                    <p class="mb-0 text-muted small">Ships within 3 days &middot; SKU VST-CR-201</p>
+                                </td>
+                                <td class="text-center">$249</td>
+                                <td class="text-center" style="min-width: 7rem;">
+                                    <h:inputText styleClass="form-control form-control-sm text-center" aria-label="Creator pack quantity" />
+                                </td>
+                                <td class="text-end">$249</td>
+                                <td class="text-end">
+                                    <h:commandLink value="Remove" styleClass="btn btn-link text-danger p-0" />
+                                </td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+                <div class="d-flex justify-content-between">
+                    <h:commandButton value="Update cart" styleClass="btn btn-outline-primary" />
+                    <h:link outcome="/products" styleClass="btn btn-link">Continue shopping</h:link>
+                </div>
+            </div>
+            <aside class="col-12 col-lg-4">
+                <div class="card shadow-sm border-0">
+                    <div class="card-body">
+                        <h2 class="h4">Order summary</h2>
+                        <dl class="row mb-0 small">
+                            <dt class="col-6">Subtotal</dt>
+                            <dd class="col-6 text-end">$1,847</dd>
+                            <dt class="col-6">Digital service fee</dt>
+                            <dd class="col-6 text-end">$25</dd>
+                            <dt class="col-6">Delivery fee</dt>
+                            <dd class="col-6 text-end">$15</dd>
+                            <dt class="col-6 fw-bold">Total</dt>
+                            <dd class="col-6 text-end fw-bold">$1,887</dd>
+                        </dl>
+                        <div class="d-grid mt-3">
+                            <h:link outcome="/checkout" styleClass="btn btn-primary btn-lg">Proceed to checkout</h:link>
+                        </div>
+                    </div>
+                </div>
+            </aside>
+        </h:form>
+    </ui:define>
+</ui:composition>

--- a/veristore/src/main/webapp/cart.xhtml
+++ b/veristore/src/main/webapp/cart.xhtml
@@ -6,77 +6,79 @@
     <ui:define name="title">Cart &ndash; Veristore</ui:define>
     <ui:define name="content">
         <h1 class="h2 mb-4">Shopping cart</h1>
-        <h:form id="cartForm" class="row g-4">
-            <div class="col-12 col-lg-8">
-                <div class="table-responsive">
-                    <table class="table align-middle">
-                        <caption class="text-muted">Adjust quantities or remove items before continuing to checkout.</caption>
-                        <thead>
-                            <tr>
-                                <th scope="col">Item</th>
-                                <th scope="col" class="text-center">Price</th>
-                                <th scope="col" class="text-center">Quantity</th>
-                                <th scope="col" class="text-end">Subtotal</th>
-                                <th scope="col" class="text-end">Actions</th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            <tr>
-                                <td>
-                                    <p class="fw-semibold mb-1">Veristore Enterprise Toolkit</p>
-                                    <p class="mb-0 text-muted small">Instant digital delivery &middot; SKU VST-ENT-993</p>
-                                </td>
-                                <td class="text-center">$799</td>
-                                <td class="text-center" style="min-width: 7rem;">
-                                    <h:inputText styleClass="form-control form-control-sm text-center" aria-label="Toolkit quantity" />
-                                </td>
-                                <td class="text-end">$1,598</td>
-                                <td class="text-end">
-                                    <h:commandLink value="Remove" styleClass="btn btn-link text-danger p-0" />
-                                </td>
-                            </tr>
-                            <tr>
-                                <td>
-                                    <p class="fw-semibold mb-1">Creator Starter Pack</p>
-                                    <p class="mb-0 text-muted small">Ships within 3 days &middot; SKU VST-CR-201</p>
-                                </td>
-                                <td class="text-center">$249</td>
-                                <td class="text-center" style="min-width: 7rem;">
-                                    <h:inputText styleClass="form-control form-control-sm text-center" aria-label="Creator pack quantity" />
-                                </td>
-                                <td class="text-end">$249</td>
-                                <td class="text-end">
-                                    <h:commandLink value="Remove" styleClass="btn btn-link text-danger p-0" />
-                                </td>
-                            </tr>
-                        </tbody>
-                    </table>
-                </div>
-                <div class="d-flex justify-content-between">
-                    <h:commandButton value="Update cart" styleClass="btn btn-outline-primary" />
-                    <h:link outcome="/products" styleClass="btn btn-link">Continue shopping</h:link>
-                </div>
-            </div>
-            <aside class="col-12 col-lg-4">
-                <div class="card shadow-sm border-0">
-                    <div class="card-body">
-                        <h2 class="h4">Order summary</h2>
-                        <dl class="row mb-0 small">
-                            <dt class="col-6">Subtotal</dt>
-                            <dd class="col-6 text-end">$1,847</dd>
-                            <dt class="col-6">Digital service fee</dt>
-                            <dd class="col-6 text-end">$25</dd>
-                            <dt class="col-6">Delivery fee</dt>
-                            <dd class="col-6 text-end">$15</dd>
-                            <dt class="col-6 fw-bold">Total</dt>
-                            <dd class="col-6 text-end fw-bold">$1,887</dd>
-                        </dl>
-                        <div class="d-grid mt-3">
-                            <h:link outcome="/checkout" styleClass="btn btn-primary btn-lg">Proceed to checkout</h:link>
-                        </div>
+        <h:panelGroup rendered="#{empty cartView.lines}" layout="block" styleClass="alert alert-info" role="status">
+            Your cart is currently empty. Browse the catalog to add items.
+        </h:panelGroup>
+        <h:panelGroup rendered="#{not empty cartView.lines}" layout="block">
+            <h:form id="cartForm" class="row g-4">
+                <div class="col-12 col-lg-8">
+                    <div class="table-responsive">
+                        <table class="table align-middle">
+                            <caption class="text-muted">Adjust quantities or remove items before continuing to checkout.</caption>
+                            <thead>
+                                <tr>
+                                    <th scope="col">Item</th>
+                                    <th scope="col" class="text-center">Price</th>
+                                    <th scope="col" class="text-center">Quantity</th>
+                                    <th scope="col" class="text-end">Subtotal</th>
+                                    <th scope="col" class="text-end">Actions</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <ui:repeat value="#{cartView.lines}" var="line" varStatus="status">
+                                    <tr>
+                                        <td>
+                                            <p class="fw-semibold mb-1">
+                                                <h:link outcome="/product">
+                                                    <f:param name="sku" value="#{line.sku}" />
+                                                    #{line.name}
+                                                </h:link>
+                                            </p>
+                                            <p class="mb-0 text-muted small">SKU #{line.sku}</p>
+                                        </td>
+                                        <td class="text-center">#{line.priceFormatted}</td>
+                                        <td class="text-center" style="min-width: 7rem;">
+                                            <h:inputText value="#{line.qty}" styleClass="form-control form-control-sm text-center"
+                                                         pt:type="number" pt:min="1" aria-label="Quantity for #{line.name}" />
+                                        </td>
+                                        <td class="text-end">#{line.totalFormatted}</td>
+                                        <td class="text-end">
+                                            <h:commandLink value="Remove" styleClass="btn btn-link text-danger p-0"
+                                                          action="#{cartView.remove(line)}"
+                                                          onclick="return confirm('Remove this item?');" />
+                                        </td>
+                                    </tr>
+                                </ui:repeat>
+                            </tbody>
+                        </table>
+                    </div>
+                    <div class="d-flex justify-content-between flex-wrap gap-2">
+                        <h:commandButton value="Update cart" styleClass="btn btn-outline-primary"
+                                         action="#{cartView.recalculate}" />
+                        <h:commandButton value="Empty cart" styleClass="btn btn-link text-danger"
+                                         action="#{cartView.empty}" />
+                        <h:link outcome="/products" styleClass="btn btn-link ms-auto">Continue shopping</h:link>
                     </div>
                 </div>
-            </aside>
-        </h:form>
+                <aside class="col-12 col-lg-4">
+                    <div class="card shadow-sm border-0">
+                        <div class="card-body">
+                            <h2 class="h4">Order summary</h2>
+                            <dl class="row mb-0 small">
+                                <dt class="col-6">Subtotal</dt>
+                                <dd class="col-6 text-end">#{cartView.subtotalFormatted()}</dd>
+                                <dt class="col-6">Service fees</dt>
+                                <dd class="col-6 text-end">#{cartView.feesFormatted()}</dd>
+                                <dt class="col-6 fw-bold">Total</dt>
+                                <dd class="col-6 text-end fw-bold">#{cartView.totalFormatted()}</dd>
+                            </dl>
+                            <div class="d-grid mt-3">
+                                <h:link outcome="/checkout" styleClass="btn btn-primary btn-lg">Proceed to checkout</h:link>
+                            </div>
+                        </div>
+                    </div>
+                </aside>
+            </h:form>
+        </h:panelGroup>
     </ui:define>
 </ui:composition>

--- a/veristore/src/main/webapp/checkout.xhtml
+++ b/veristore/src/main/webapp/checkout.xhtml
@@ -7,117 +7,94 @@
     <ui:define name="title">Checkout &ndash; Veristore</ui:define>
     <ui:define name="content">
         <h1 class="h2 mb-4">Secure checkout</h1>
-        <h:form id="checkoutForm" class="row g-4">
-            <section class="col-12 col-lg-8">
-                <article class="card shadow-sm border-0 mb-4">
-                    <div class="card-body">
-                        <h2 class="h4">Contact information</h2>
-                        <div class="row g-3 mt-2">
-                            <div class="col-12 col-md-6">
-                                <h:outputLabel for="firstName" value="First name" styleClass="form-label" />
-                                <h:inputText id="firstName" styleClass="form-control" required="true" />
-                            </div>
-                            <div class="col-12 col-md-6">
-                                <h:outputLabel for="lastName" value="Last name" styleClass="form-label" />
-                                <h:inputText id="lastName" styleClass="form-control" required="true" />
-                            </div>
-                            <div class="col-12">
-                                <h:outputLabel for="email" value="Email" styleClass="form-label" />
-                                <h:inputText id="email" styleClass="form-control" required="true" />
-                            </div>
-                            <div class="col-12">
-                                <h:outputLabel for="phone" value="Phone" styleClass="form-label" />
-                                <h:inputText id="phone" styleClass="form-control" />
+        <h:panelGroup rendered="#{empty checkoutView.lines}" layout="block" styleClass="alert alert-info" role="status">
+            Your checkout session is empty. Add items to your cart before continuing.
+        </h:panelGroup>
+        <h:panelGroup rendered="#{not empty checkoutView.lines}" layout="block">
+            <h:form id="checkoutForm" class="row g-4">
+                <section class="col-12 col-lg-8">
+                    <article class="card shadow-sm border-0 mb-4">
+                        <div class="card-body">
+                            <h2 class="h4">Contact information</h2>
+                            <div class="row g-3 mt-2">
+                                <div class="col-12">
+                                    <h:outputLabel for="email" value="Email" styleClass="form-label" />
+                                    <h:inputText id="email" styleClass="form-control" value="#{checkoutView.email}" required="true"
+                                                 pt:type="email" />
+                                </div>
+                                <div class="col-12">
+                                    <h:outputLabel for="phone" value="Phone" styleClass="form-label" />
+                                    <h:inputText id="phone" styleClass="form-control" value="#{checkoutView.phone}" />
+                                </div>
                             </div>
                         </div>
-                    </div>
-                </article>
-                <article class="card shadow-sm border-0 mb-4">
-                    <div class="card-body">
-                        <h2 id="deliveryHeading" class="h4">Delivery preferences</h2>
-                        <div class="mt-3 vstack gap-3" role="radiogroup" aria-labelledby="deliveryHeading">
-                            <div class="form-check">
-                                <input class="form-check-input" type="radio" name="deliveryOption" id="deliveryDigital" value="digital" checked="checked" />
-                                <label class="form-check-label" for="deliveryDigital">
-                                    <span class="d-block fw-semibold">Instant digital fulfillment</span>
-                                    <span class="text-muted small">Receive secure download links immediately.</span>
-                                </label>
-                            </div>
-                            <div class="form-check">
-                                <input class="form-check-input" type="radio" name="deliveryOption" id="deliveryCourier" value="courier" />
-                                <label class="form-check-label" for="deliveryCourier">
-                                    <span class="d-block fw-semibold">Local courier (1-2 days)</span>
-                                    <span class="text-muted small">Tracked handoff with signature verification.</span>
-                                </label>
-                            </div>
-                            <div class="form-check">
-                                <input class="form-check-input" type="radio" name="deliveryOption" id="deliveryEnterprise" value="enterprise" />
-                                <label class="form-check-label" for="deliveryEnterprise">
-                                    <span class="d-block fw-semibold">Scheduled enterprise deployment</span>
-                                    <span class="text-muted small">Coordinate rollout with delivery engineers.</span>
-                                </label>
-                            </div>
-                        </div>
-                    </div>
-                </article>
-                <article class="card shadow-sm border-0">
-                    <div class="card-body">
-                        <h2 class="h4">Payment</h2>
-                        <div class="row g-3 mt-2">
-                            <div class="col-12">
-                                <h:outputLabel for="cardNumber" value="Card number" styleClass="form-label" />
-                                <h:inputText id="cardNumber" styleClass="form-control" autocomplete="cc-number" />
-                            </div>
-                            <div class="col-6 col-md-3">
-                                <h:outputLabel for="expiry" value="Expiry" styleClass="form-label" />
-                                <h:inputText id="expiry" styleClass="form-control" placeholder="MM/YY" />
-                            </div>
-                            <div class="col-6 col-md-3">
-                                <h:outputLabel for="cvv" value="CVV" styleClass="form-label" />
-                                <h:inputText id="cvv" styleClass="form-control" />
-                            </div>
-                            <div class="col-12">
+                    </article>
+                    <article class="card shadow-sm border-0 mb-4">
+                        <div class="card-body">
+                            <h2 id="deliveryHeading" class="h4">Delivery preferences</h2>
+                            <div class="mt-3 vstack gap-2" role="group" aria-labelledby="deliveryHeading">
                                 <div class="form-check">
-                                    <h:selectBooleanCheckbox id="saveDetails" styleClass="form-check-input" />
-                                    <h:outputLabel for="saveDetails" styleClass="form-check-label">Save payment method for future orders</h:outputLabel>
+                                    <h:selectBooleanCheckbox id="deliverEmail" value="#{checkoutView.deliverByEmail}" styleClass="form-check-input" />
+                                    <h:outputLabel for="deliverEmail" styleClass="form-check-label">
+                                        Send fulfillment updates by email
+                                    </h:outputLabel>
+                                </div>
+                                <div class="form-check">
+                                    <h:selectBooleanCheckbox id="deliverSms" value="#{checkoutView.deliverBySms}" styleClass="form-check-input" />
+                                    <h:outputLabel for="deliverSms" styleClass="form-check-label">
+                                        Send SMS alerts for delivery milestones
+                                    </h:outputLabel>
                                 </div>
                             </div>
                         </div>
-                    </div>
-                </article>
-            </section>
-            <aside class="col-12 col-lg-4">
-                <div class="card shadow-sm border-0">
-                    <div class="card-body">
-                        <h2 class="h4">Order summary</h2>
-                        <ul class="list-group list-group-flush my-3">
-                            <li class="list-group-item d-flex justify-content-between align-items-start">
-                                <div>
-                                    <p class="fw-semibold mb-1">Veristore Enterprise Toolkit</p>
-                                    <p class="mb-0 text-muted small">2 &times; license pack</p>
-                                </div>
-                                <span>$1,598</span>
-                            </li>
-                            <li class="list-group-item d-flex justify-content-between">
-                                <span>Creator Starter Pack</span>
-                                <span>$249</span>
-                            </li>
-                        </ul>
-                        <dl class="row small mb-0">
-                            <dt class="col-6">Subtotal</dt>
-                            <dd class="col-6 text-end">$1,847</dd>
-                            <dt class="col-6">Service fees</dt>
-                            <dd class="col-6 text-end">$40</dd>
-                            <dt class="col-6 fw-bold">Total due</dt>
-                            <dd class="col-6 text-end fw-bold">$1,887</dd>
-                        </dl>
-                        <div class="d-grid mt-4">
-                            <h:commandButton value="Pay now" styleClass="btn btn-primary btn-lg" />
+                    </article>
+                    <article class="card shadow-sm border-0">
+                        <div class="card-body">
+                            <h2 class="h4">Payment</h2>
+                            <p class="text-muted">We will redirect you to our secure payment partner to collect billing details.</p>
+                            <div class="d-flex gap-2">
+                                <h:commandButton value="Pay now" styleClass="btn btn-primary"
+                                                 action="#{checkoutView.pay}" />
+                                <h:commandLink value="Cancel" styleClass="btn btn-outline-secondary"
+                                               action="#{checkoutView.cancel}" immediate="true" />
+                            </div>
+                            <h:panelGroup rendered="#{checkoutView.showStatusPanel}" layout="block" styleClass="alert alert-info mt-3" role="status">
+                                <p class="mb-1">#{checkoutView.paymentStatus}</p>
+                                <h:panelGroup rendered="#{checkoutView.paymentRedirect ne null}">
+                                    <a href="#{checkoutView.paymentRedirect}" class="alert-link">Continue to payment portal</a>
+                                </h:panelGroup>
+                            </h:panelGroup>
                         </div>
-                        <p class="small text-muted mt-3">Payments are processed securely through Veristore Pay with PCI DSS compliance.</p>
+                    </article>
+                </section>
+                <aside class="col-12 col-lg-4">
+                    <div class="card shadow-sm border-0">
+                        <div class="card-body">
+                            <h2 class="h4">Order summary</h2>
+                            <ul class="list-group list-group-flush my-3">
+                                <ui:repeat value="#{checkoutView.lines}" var="line">
+                                    <li class="list-group-item d-flex justify-content-between align-items-start">
+                                        <div>
+                                            <p class="fw-semibold mb-1">#{line.name}</p>
+                                            <p class="mb-0 text-muted small">#{line.qty} &times; #{line.priceFormatted}</p>
+                                        </div>
+                                        <span>#{line.totalFormatted}</span>
+                                    </li>
+                                </ui:repeat>
+                            </ul>
+                            <dl class="row small mb-0">
+                                <dt class="col-6">Subtotal</dt>
+                                <dd class="col-6 text-end">#{checkoutView.subtotalFormatted}</dd>
+                                <dt class="col-6">Service fees</dt>
+                                <dd class="col-6 text-end">#{checkoutView.feesFormatted}</dd>
+                                <dt class="col-6 fw-bold">Total due</dt>
+                                <dd class="col-6 text-end fw-bold">#{checkoutView.totalFormatted}</dd>
+                            </dl>
+                            <p class="small text-muted mt-3">Payments are processed securely through Veristore Pay with PCI DSS compliance.</p>
+                        </div>
                     </div>
-                </div>
-            </aside>
-        </h:form>
+                </aside>
+            </h:form>
+        </h:panelGroup>
     </ui:define>
 </ui:composition>

--- a/veristore/src/main/webapp/checkout.xhtml
+++ b/veristore/src/main/webapp/checkout.xhtml
@@ -1,0 +1,123 @@
+<!DOCTYPE html>
+<ui:composition xmlns="http://www.w3.org/1999/xhtml"
+                xmlns:h="http://xmlns.jcp.org/jsf/html"
+                xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+                xmlns:f="http://xmlns.jcp.org/jsf/core"
+                template="/WEB-INF/template.xhtml">
+    <ui:define name="title">Checkout &ndash; Veristore</ui:define>
+    <ui:define name="content">
+        <h1 class="h2 mb-4">Secure checkout</h1>
+        <h:form id="checkoutForm" class="row g-4">
+            <section class="col-12 col-lg-8">
+                <article class="card shadow-sm border-0 mb-4">
+                    <div class="card-body">
+                        <h2 class="h4">Contact information</h2>
+                        <div class="row g-3 mt-2">
+                            <div class="col-12 col-md-6">
+                                <h:outputLabel for="firstName" value="First name" styleClass="form-label" />
+                                <h:inputText id="firstName" styleClass="form-control" required="true" />
+                            </div>
+                            <div class="col-12 col-md-6">
+                                <h:outputLabel for="lastName" value="Last name" styleClass="form-label" />
+                                <h:inputText id="lastName" styleClass="form-control" required="true" />
+                            </div>
+                            <div class="col-12">
+                                <h:outputLabel for="email" value="Email" styleClass="form-label" />
+                                <h:inputText id="email" styleClass="form-control" required="true" />
+                            </div>
+                            <div class="col-12">
+                                <h:outputLabel for="phone" value="Phone" styleClass="form-label" />
+                                <h:inputText id="phone" styleClass="form-control" />
+                            </div>
+                        </div>
+                    </div>
+                </article>
+                <article class="card shadow-sm border-0 mb-4">
+                    <div class="card-body">
+                        <h2 id="deliveryHeading" class="h4">Delivery preferences</h2>
+                        <div class="mt-3 vstack gap-3" role="radiogroup" aria-labelledby="deliveryHeading">
+                            <div class="form-check">
+                                <input class="form-check-input" type="radio" name="deliveryOption" id="deliveryDigital" value="digital" checked="checked" />
+                                <label class="form-check-label" for="deliveryDigital">
+                                    <span class="d-block fw-semibold">Instant digital fulfillment</span>
+                                    <span class="text-muted small">Receive secure download links immediately.</span>
+                                </label>
+                            </div>
+                            <div class="form-check">
+                                <input class="form-check-input" type="radio" name="deliveryOption" id="deliveryCourier" value="courier" />
+                                <label class="form-check-label" for="deliveryCourier">
+                                    <span class="d-block fw-semibold">Local courier (1-2 days)</span>
+                                    <span class="text-muted small">Tracked handoff with signature verification.</span>
+                                </label>
+                            </div>
+                            <div class="form-check">
+                                <input class="form-check-input" type="radio" name="deliveryOption" id="deliveryEnterprise" value="enterprise" />
+                                <label class="form-check-label" for="deliveryEnterprise">
+                                    <span class="d-block fw-semibold">Scheduled enterprise deployment</span>
+                                    <span class="text-muted small">Coordinate rollout with delivery engineers.</span>
+                                </label>
+                            </div>
+                        </div>
+                    </div>
+                </article>
+                <article class="card shadow-sm border-0">
+                    <div class="card-body">
+                        <h2 class="h4">Payment</h2>
+                        <div class="row g-3 mt-2">
+                            <div class="col-12">
+                                <h:outputLabel for="cardNumber" value="Card number" styleClass="form-label" />
+                                <h:inputText id="cardNumber" styleClass="form-control" autocomplete="cc-number" />
+                            </div>
+                            <div class="col-6 col-md-3">
+                                <h:outputLabel for="expiry" value="Expiry" styleClass="form-label" />
+                                <h:inputText id="expiry" styleClass="form-control" placeholder="MM/YY" />
+                            </div>
+                            <div class="col-6 col-md-3">
+                                <h:outputLabel for="cvv" value="CVV" styleClass="form-label" />
+                                <h:inputText id="cvv" styleClass="form-control" />
+                            </div>
+                            <div class="col-12">
+                                <div class="form-check">
+                                    <h:selectBooleanCheckbox id="saveDetails" styleClass="form-check-input" />
+                                    <h:outputLabel for="saveDetails" styleClass="form-check-label">Save payment method for future orders</h:outputLabel>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </article>
+            </section>
+            <aside class="col-12 col-lg-4">
+                <div class="card shadow-sm border-0">
+                    <div class="card-body">
+                        <h2 class="h4">Order summary</h2>
+                        <ul class="list-group list-group-flush my-3">
+                            <li class="list-group-item d-flex justify-content-between align-items-start">
+                                <div>
+                                    <p class="fw-semibold mb-1">Veristore Enterprise Toolkit</p>
+                                    <p class="mb-0 text-muted small">2 &times; license pack</p>
+                                </div>
+                                <span>$1,598</span>
+                            </li>
+                            <li class="list-group-item d-flex justify-content-between">
+                                <span>Creator Starter Pack</span>
+                                <span>$249</span>
+                            </li>
+                        </ul>
+                        <dl class="row small mb-0">
+                            <dt class="col-6">Subtotal</dt>
+                            <dd class="col-6 text-end">$1,847</dd>
+                            <dt class="col-6">Service fees</dt>
+                            <dd class="col-6 text-end">$40</dd>
+                            <dt class="col-6 fw-bold">Total due</dt>
+                            <dd class="col-6 text-end fw-bold">$1,887</dd>
+                        </dl>
+                        <div class="d-grid mt-4">
+                            <h:commandButton value="Pay now" styleClass="btn btn-primary btn-lg" />
+                        </div>
+                        <p class="small text-muted mt-3">Payments are processed securely through Veristore Pay with PCI DSS compliance.</p>
+                    </div>
+                </div>
+            </aside>
+        </h:form>
+    </ui:define>
+</ui:composition>

--- a/veristore/src/main/webapp/index.xhtml
+++ b/veristore/src/main/webapp/index.xhtml
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<ui:composition xmlns="http://www.w3.org/1999/xhtml"
+                xmlns:h="http://xmlns.jcp.org/jsf/html"
+                xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+                template="/WEB-INF/template.xhtml">
+    <ui:define name="title">Veristore &ndash; Discover trusted digital and physical goods</ui:define>
+    <ui:define name="content">
+        <section class="row g-5 align-items-center" aria-labelledby="heroHeading">
+            <div class="col-12 col-lg-6">
+                <span class="badge bg-primary text-uppercase mb-3">Trusted marketplace</span>
+                <h1 id="heroHeading" class="display-5 fw-bold mb-3">Commerce designed for verifiable fulfillment</h1>
+                <p class="lead mb-4">Source digital licenses, physical goods, and managed services from rigorously vetted providers with transparent delivery status.</p>
+                <div class="d-flex flex-column flex-sm-row gap-3">
+                    <h:link outcome="/products" styleClass="btn btn-primary btn-lg">Browse catalog</h:link>
+                    <h:link outcome="/checkout" styleClass="btn btn-outline-primary btn-lg">Secure checkout</h:link>
+                </div>
+            </div>
+            <div class="col-12 col-lg-6">
+                <div class="position-relative overflow-hidden rounded-4 shadow-sm bg-white">
+                    <div class="ratio ratio-16x9 bg-gradient" style="background: radial-gradient(circle at 20% 20%, rgba(13,110,253,.2), transparent 60%), radial-gradient(circle at 80% 0%, rgba(25,135,84,.25), transparent 55%), #f8f9fa;">
+                        <div class="position-absolute top-50 start-50 translate-middle text-center px-4">
+                            <p class="h4 fw-semibold mb-1">Real-time verification</p>
+                            <p class="text-muted mb-0">Monitor inventory trust scores, compliance attestations, and delivery milestones in one view.</p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <section class="mt-5 pt-4 border-top" aria-labelledby="popularCategories">
+            <div class="d-flex justify-content-between align-items-center flex-wrap gap-3 mb-4">
+                <div>
+                    <h2 id="popularCategories" class="h3 mb-1">Popular categories</h2>
+                    <p class="text-muted mb-0">Blueprint-aligned bundles curated by fulfillment type.</p>
+                </div>
+                <h:link outcome="/products" styleClass="btn btn-outline-secondary">View all products</h:link>
+            </div>
+            <div class="row row-cols-1 row-cols-sm-2 row-cols-lg-4 g-4">
+                <div class="col">
+                    <article class="card h-100 border-0 shadow-sm" aria-labelledby="catDigital">
+                        <div class="card-body">
+                            <h3 id="catDigital" class="h5">Digital keys</h3>
+                            <p class="text-muted">Instant license delivery with audit trails and revocation controls.</p>
+                            <h:link outcome="/products" styleClass="stretched-link">Explore</h:link>
+                        </div>
+                    </article>
+                </div>
+                <div class="col">
+                    <article class="card h-100 border-0 shadow-sm" aria-labelledby="catCreator">
+                        <div class="card-body">
+                            <h3 id="catCreator" class="h5">Creator kits</h3>
+                            <p class="text-muted">Streamlined gear bundles with insured courier delivery.</p>
+                            <h:link outcome="/products" styleClass="stretched-link">Explore</h:link>
+                        </div>
+                    </article>
+                </div>
+                <div class="col">
+                    <article class="card h-100 border-0 shadow-sm" aria-labelledby="catWellness">
+                        <div class="card-body">
+                            <h3 id="catWellness" class="h5">Wellness essentials</h3>
+                            <p class="text-muted">Clinically reviewed devices and supplements with proactive tracking.</p>
+                            <h:link outcome="/products" styleClass="stretched-link">Explore</h:link>
+                        </div>
+                    </article>
+                </div>
+                <div class="col">
+                    <article class="card h-100 border-0 shadow-sm" aria-labelledby="catEnterprise">
+                        <div class="card-body">
+                            <h3 id="catEnterprise" class="h5">Enterprise services</h3>
+                            <p class="text-muted">Managed deployment, compliance operations, and customer support programs.</p>
+                            <h:link outcome="/products" styleClass="stretched-link">Explore</h:link>
+                        </div>
+                    </article>
+                </div>
+            </div>
+        </section>
+    </ui:define>
+</ui:composition>

--- a/veristore/src/main/webapp/order-success.xhtml
+++ b/veristore/src/main/webapp/order-success.xhtml
@@ -1,0 +1,85 @@
+<!DOCTYPE html>
+<ui:composition xmlns="http://www.w3.org/1999/xhtml"
+                xmlns:h="http://xmlns.jcp.org/jsf/html"
+                xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+                template="/WEB-INF/template.xhtml">
+    <ui:define name="title">Order confirmed &ndash; Veristore</ui:define>
+    <ui:define name="content">
+        <h:form id="orderActions" class="d-flex flex-column gap-5">
+            <section class="text-center py-5">
+                <div class="mb-4">
+                    <span class="display-4" role="img" aria-label="Success">🎉</span>
+                </div>
+                <h1 class="h2">Thank you! Your order is confirmed.</h1>
+                <p class="text-muted">A confirmation email has been sent to <strong>you@example.com</strong>. Keep your masked codes safe.</p>
+            </section>
+            <section class="row g-4" aria-label="Digital fulfillment codes">
+                <div class="col-12 col-lg-6">
+                    <article class="card shadow-sm border-0 h-100">
+                        <div class="card-body">
+                            <h2 class="h4">Veristore Enterprise Toolkit</h2>
+                            <p class="text-muted">Order VST-448291 &middot; Instant digital fulfillment</p>
+                            <div class="bg-light rounded p-3 mb-3">
+                                <p class="mb-0 fw-semibold" aria-label="License code">VST-ENT-****-19Q4</p>
+                            </div>
+                            <div class="d-flex flex-wrap gap-2">
+                                <h:commandLink value="Copy code" styleClass="btn btn-outline-primary btn-sm" />
+                                <h:commandLink value="Resend email" styleClass="btn btn-link btn-sm" />
+                            </div>
+                        </div>
+                    </article>
+                </div>
+                <div class="col-12 col-lg-6">
+                    <article class="card shadow-sm border-0 h-100">
+                        <div class="card-body">
+                            <h2 class="h4">Creator Starter Pack</h2>
+                            <p class="text-muted">Shipment VST-992331 &middot; Courier delivery</p>
+                            <div class="bg-light rounded p-3 mb-3">
+                                <p class="mb-0 fw-semibold" aria-label="Tracking code">TRK-****-9241</p>
+                            </div>
+                            <div class="d-flex flex-wrap gap-2">
+                                <h:commandLink value="Track package" styleClass="btn btn-outline-primary btn-sm" />
+                                <h:commandLink value="Resend SMS" styleClass="btn btn-link btn-sm" />
+                            </div>
+                        </div>
+                    </article>
+                </div>
+            </section>
+            <section class="mt-2" aria-labelledby="postPurchase">
+                <h2 id="postPurchase" class="h4">Next steps</h2>
+                <div class="row g-4">
+                    <div class="col-12 col-md-4">
+                        <div class="card border-0 shadow-sm h-100">
+                            <div class="card-body">
+                                <h3 class="h5">Schedule onboarding</h3>
+                                <p class="text-muted">Reserve time with a deployment specialist for enterprise toolkit configuration.</p>
+                                <h:commandLink value="Book session" styleClass="btn btn-outline-primary btn-sm" />
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col-12 col-md-4">
+                        <div class="card border-0 shadow-sm h-100">
+                            <div class="card-body">
+                                <h3 class="h5">Invite teammates</h3>
+                                <p class="text-muted">Share secure invitations so colleagues can access their fulfillment codes.</p>
+                                <h:commandLink value="Send invites" styleClass="btn btn-outline-primary btn-sm" />
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col-12 col-md-4">
+                        <div class="card border-0 shadow-sm h-100">
+                            <div class="card-body">
+                                <h3 class="h5">Download invoice</h3>
+                                <p class="text-muted">Generate a detailed invoice with tax breakdown and compliance metadata.</p>
+                                <h:commandLink value="Download" styleClass="btn btn-outline-primary btn-sm" />
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div class="mt-4">
+                    <h:link outcome="/products" styleClass="btn btn-link">Continue shopping</h:link>
+                </div>
+            </section>
+        </h:form>
+    </ui:define>
+</ui:composition>

--- a/veristore/src/main/webapp/order-success.xhtml
+++ b/veristore/src/main/webapp/order-success.xhtml
@@ -11,40 +11,36 @@
                     <span class="display-4" role="img" aria-label="Success">🎉</span>
                 </div>
                 <h1 class="h2">Thank you! Your order is confirmed.</h1>
-                <p class="text-muted">A confirmation email has been sent to <strong>you@example.com</strong>. Keep your masked codes safe.</p>
+                <h:panelGroup rendered="#{orderView.loaded}" layout="block">
+                    <p class="text-muted">Order reference <strong>#{orderView.order.publicId}</strong> is being prepared.</p>
+                </h:panelGroup>
+                <h:panelGroup rendered="#{not orderView.loaded}" layout="block" styleClass="alert alert-warning mt-3" role="alert">
+                    We could not locate your order details. Please verify the link from your confirmation email.
+                </h:panelGroup>
             </section>
-            <section class="row g-4" aria-label="Digital fulfillment codes">
-                <div class="col-12 col-lg-6">
-                    <article class="card shadow-sm border-0 h-100">
-                        <div class="card-body">
-                            <h2 class="h4">Veristore Enterprise Toolkit</h2>
-                            <p class="text-muted">Order VST-448291 &middot; Instant digital fulfillment</p>
-                            <div class="bg-light rounded p-3 mb-3">
-                                <p class="mb-0 fw-semibold" aria-label="License code">VST-ENT-****-19Q4</p>
+            <h:panelGroup rendered="#{orderView.loaded}" layout="block">
+                <section class="row g-4" aria-label="Digital fulfillment codes">
+                    <div class="col-12">
+                        <article class="card shadow-sm border-0 h-100">
+                            <div class="card-body">
+                                <h2 class="h4">Fulfillment codes</h2>
+                                <p class="text-muted">Your secure access codes are masked for protection. Resend them at any time.</p>
+                                <ui:repeat value="#{orderView.maskedCodes()}" var="code" varStatus="status">
+                                    <div class="bg-light rounded p-3 mb-3 d-flex justify-content-between align-items-center">
+                                        <span class="fw-semibold" aria-label="Masked code #{status.index + 1}">#{code}</span>
+                                        <div class="d-flex flex-wrap gap-2">
+                                            <h:commandLink value="Resend email" styleClass="btn btn-link btn-sm"
+                                                           action="#{orderView.resendEmail}" />
+                                            <h:commandLink value="Resend SMS" styleClass="btn btn-link btn-sm"
+                                                           action="#{orderView.resendSms}" />
+                                        </div>
+                                    </div>
+                                </ui:repeat>
                             </div>
-                            <div class="d-flex flex-wrap gap-2">
-                                <h:commandLink value="Copy code" styleClass="btn btn-outline-primary btn-sm" />
-                                <h:commandLink value="Resend email" styleClass="btn btn-link btn-sm" />
-                            </div>
-                        </div>
-                    </article>
-                </div>
-                <div class="col-12 col-lg-6">
-                    <article class="card shadow-sm border-0 h-100">
-                        <div class="card-body">
-                            <h2 class="h4">Creator Starter Pack</h2>
-                            <p class="text-muted">Shipment VST-992331 &middot; Courier delivery</p>
-                            <div class="bg-light rounded p-3 mb-3">
-                                <p class="mb-0 fw-semibold" aria-label="Tracking code">TRK-****-9241</p>
-                            </div>
-                            <div class="d-flex flex-wrap gap-2">
-                                <h:commandLink value="Track package" styleClass="btn btn-outline-primary btn-sm" />
-                                <h:commandLink value="Resend SMS" styleClass="btn btn-link btn-sm" />
-                            </div>
-                        </div>
-                    </article>
-                </div>
-            </section>
+                        </article>
+                    </div>
+                </section>
+            </h:panelGroup>
             <section class="mt-2" aria-labelledby="postPurchase">
                 <h2 id="postPurchase" class="h4">Next steps</h2>
                 <div class="row g-4">

--- a/veristore/src/main/webapp/product.xhtml
+++ b/veristore/src/main/webapp/product.xhtml
@@ -10,70 +10,63 @@
             <ol class="breadcrumb small">
                 <li class="breadcrumb-item"><h:link outcome="/index">Home</h:link></li>
                 <li class="breadcrumb-item"><h:link outcome="/products">Products</h:link></li>
-                <li class="breadcrumb-item active" aria-current="page">Veristore Enterprise Toolkit</li>
+                <li class="breadcrumb-item active" aria-current="page">#{productDetailView.item != null ? productDetailView.item.name : 'Product'}</li>
             </ol>
         </nav>
-        <div class="row g-5">
-            <section class="col-12 col-lg-7" aria-labelledby="productTitle">
-                <span class="badge bg-secondary mb-3">Digital delivery</span>
-                <h1 id="productTitle" class="h2">Veristore Enterprise Toolkit</h1>
-                <p class="lead">Centralized licenses, compliance automation, and onboarding workflows built for scaling organizations.</p>
-                <dl class="row small">
-                    <dt class="col-4 col-sm-3">SKU</dt>
-                    <dd class="col-8 col-sm-9">VST-ENT-993</dd>
-                    <dt class="col-4 col-sm-3">Availability</dt>
-                    <dd class="col-8 col-sm-9">Instant fulfillment</dd>
-                    <dt class="col-4 col-sm-3">Support</dt>
-                    <dd class="col-8 col-sm-9">Dedicated account specialist</dd>
-                </dl>
-                <section aria-labelledby="featuresHeading" class="mt-4">
-                    <h2 id="featuresHeading" class="h4">Highlights</h2>
-                    <ul class="list-unstyled" role="list">
-                        <li class="d-flex align-items-start gap-3 mb-2">
-                            <span class="text-primary" aria-hidden="true">&#10003;</span>
-                            <span>Automated provisioning to major identity providers.</span>
-                        </li>
-                        <li class="d-flex align-items-start gap-3 mb-2">
-                            <span class="text-primary" aria-hidden="true">&#10003;</span>
-                            <span>Audit-ready export of user activity and license consumption.</span>
-                        </li>
-                        <li class="d-flex align-items-start gap-3">
-                            <span class="text-primary" aria-hidden="true">&#10003;</span>
-                            <span>24/7 escalation channel with service-level guarantees.</span>
-                        </li>
-                    </ul>
+        <h:panelGroup rendered="#{productDetailView.item eq null}" layout="block" styleClass="alert alert-warning" role="alert">
+            The requested product could not be found.
+        </h:panelGroup>
+        <h:panelGroup layout="block" rendered="#{productDetailView.item ne null}">
+            <div class="row g-5">
+                <section class="col-12 col-lg-7" aria-labelledby="productTitle">
+                    <span class="badge bg-secondary mb-3">#{productDetailView.item.category}</span>
+                    <h1 id="productTitle" class="h2">#{productDetailView.item.name}</h1>
+                    <p class="lead">#{productDetailView.item.shortDesc}</p>
+                    <dl class="row small">
+                        <dt class="col-4 col-sm-3">SKU</dt>
+                        <dd class="col-8 col-sm-9">#{productDetailView.item.sku}</dd>
+                        <dt class="col-4 col-sm-3">Country</dt>
+                        <dd class="col-8 col-sm-9">#{productDetailView.item.country}</dd>
+                        <dt class="col-4 col-sm-3">Category</dt>
+                        <dd class="col-8 col-sm-9">#{productDetailView.item.category}</dd>
+                    </dl>
+                    <section aria-labelledby="featuresHeading" class="mt-4">
+                        <h2 id="featuresHeading" class="h4">Overview</h2>
+                        <p class="text-muted">#{productDetailView.item.longDesc}</p>
+                    </section>
                 </section>
-            </section>
-            <aside class="col-12 col-lg-5" aria-label="Purchase options">
-                <div class="card shadow-sm border-0">
-                    <div class="card-body">
-                        <h2 class="h4">Purchase</h2>
-                        <p class="h3 mb-4">$799 <span class="fs-6 text-muted">per license pack</span></p>
-                        <h:form id="purchaseForm" class="vstack gap-3">
-                            <div>
-                                <h:outputLabel for="quantity" value="Quantity" styleClass="form-label" />
-                                <h:inputText id="quantity" value="1" styleClass="form-control" pt:type="number" pt:min="1" pt:aria-describedby="quantityHelp" />
-                                <div id="quantityHelp" class="form-text">Enter the number of license packs you require.</div>
+                <aside class="col-12 col-lg-5" aria-label="Purchase options">
+                    <div class="card shadow-sm border-0">
+                        <div class="card-body">
+                            <h2 class="h4">Purchase</h2>
+                            <p class="h3 mb-4">#{productDetailView.item.priceFormatted}</p>
+                            <h:form id="purchaseForm" class="vstack gap-3">
+                                <div>
+                                    <h:outputLabel for="quantity" value="Quantity" styleClass="form-label" />
+                                    <h:inputText id="quantity" value="#{productDetailView.qty}" styleClass="form-control"
+                                                 pt:type="number" pt:min="1" pt:aria-describedby="quantityHelp" />
+                                    <div id="quantityHelp" class="form-text">Enter the number of items you require.</div>
+                                </div>
+                                <div class="form-check">
+                                    <h:selectBooleanCheckbox id="tos" value="#{productDetailView.acceptedTos}" styleClass="form-check-input" />
+                                    <h:outputLabel for="tos" styleClass="form-check-label">
+                                        I agree to the <a href="#" class="link-primary">Terms of Service</a> and acknowledge the service level definitions.
+                                    </h:outputLabel>
+                                </div>
+                                <h:commandButton value="Add to cart" styleClass="btn btn-primary btn-lg" action="#{productDetailView.addToCart}" />
+                            </h:form>
+                            <div class="mt-4">
+                                <h3 class="h5">Trust signals</h3>
+                                <ul class="list-unstyled small mb-0">
+                                    <li>Secure payments processed via Veristore Pay</li>
+                                    <li>Instant delivery with audit trail</li>
+                                    <li>Money-back guarantee within 30 days</li>
+                                </ul>
                             </div>
-                            <div class="form-check">
-                                <h:selectBooleanCheckbox id="tos" styleClass="form-check-input" />
-                                <h:outputLabel for="tos" styleClass="form-check-label">
-                                    I agree to the <a href="#" class="link-primary">Terms of Service</a> and acknowledge the service level definitions.
-                                </h:outputLabel>
-                            </div>
-                            <h:commandButton value="Add to cart" styleClass="btn btn-primary btn-lg" />
-                        </h:form>
-                        <div class="mt-4">
-                            <h3 class="h5">Trust signals</h3>
-                            <ul class="list-unstyled small mb-0">
-                                <li>Secure payments processed via Veristore Pay</li>
-                                <li>Instant delivery with audit trail</li>
-                                <li>Money-back guarantee within 30 days</li>
-                            </ul>
                         </div>
                     </div>
-                </div>
-            </aside>
-        </div>
+                </aside>
+            </div>
+        </h:panelGroup>
     </ui:define>
 </ui:composition>

--- a/veristore/src/main/webapp/product.xhtml
+++ b/veristore/src/main/webapp/product.xhtml
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<ui:composition xmlns="http://www.w3.org/1999/xhtml"
+                xmlns:h="http://xmlns.jcp.org/jsf/html"
+                xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+                xmlns:pt="http://xmlns.jcp.org/jsf/passthrough"
+                template="/WEB-INF/template.xhtml">
+    <ui:define name="title">Product detail &ndash; Veristore</ui:define>
+    <ui:define name="content">
+        <nav aria-label="Breadcrumb" class="mb-3">
+            <ol class="breadcrumb small">
+                <li class="breadcrumb-item"><h:link outcome="/index">Home</h:link></li>
+                <li class="breadcrumb-item"><h:link outcome="/products">Products</h:link></li>
+                <li class="breadcrumb-item active" aria-current="page">Veristore Enterprise Toolkit</li>
+            </ol>
+        </nav>
+        <div class="row g-5">
+            <section class="col-12 col-lg-7" aria-labelledby="productTitle">
+                <span class="badge bg-secondary mb-3">Digital delivery</span>
+                <h1 id="productTitle" class="h2">Veristore Enterprise Toolkit</h1>
+                <p class="lead">Centralized licenses, compliance automation, and onboarding workflows built for scaling organizations.</p>
+                <dl class="row small">
+                    <dt class="col-4 col-sm-3">SKU</dt>
+                    <dd class="col-8 col-sm-9">VST-ENT-993</dd>
+                    <dt class="col-4 col-sm-3">Availability</dt>
+                    <dd class="col-8 col-sm-9">Instant fulfillment</dd>
+                    <dt class="col-4 col-sm-3">Support</dt>
+                    <dd class="col-8 col-sm-9">Dedicated account specialist</dd>
+                </dl>
+                <section aria-labelledby="featuresHeading" class="mt-4">
+                    <h2 id="featuresHeading" class="h4">Highlights</h2>
+                    <ul class="list-unstyled" role="list">
+                        <li class="d-flex align-items-start gap-3 mb-2">
+                            <span class="text-primary" aria-hidden="true">&#10003;</span>
+                            <span>Automated provisioning to major identity providers.</span>
+                        </li>
+                        <li class="d-flex align-items-start gap-3 mb-2">
+                            <span class="text-primary" aria-hidden="true">&#10003;</span>
+                            <span>Audit-ready export of user activity and license consumption.</span>
+                        </li>
+                        <li class="d-flex align-items-start gap-3">
+                            <span class="text-primary" aria-hidden="true">&#10003;</span>
+                            <span>24/7 escalation channel with service-level guarantees.</span>
+                        </li>
+                    </ul>
+                </section>
+            </section>
+            <aside class="col-12 col-lg-5" aria-label="Purchase options">
+                <div class="card shadow-sm border-0">
+                    <div class="card-body">
+                        <h2 class="h4">Purchase</h2>
+                        <p class="h3 mb-4">$799 <span class="fs-6 text-muted">per license pack</span></p>
+                        <h:form id="purchaseForm" class="vstack gap-3">
+                            <div>
+                                <h:outputLabel for="quantity" value="Quantity" styleClass="form-label" />
+                                <h:inputText id="quantity" value="1" styleClass="form-control" pt:type="number" pt:min="1" pt:aria-describedby="quantityHelp" />
+                                <div id="quantityHelp" class="form-text">Enter the number of license packs you require.</div>
+                            </div>
+                            <div class="form-check">
+                                <h:selectBooleanCheckbox id="tos" styleClass="form-check-input" />
+                                <h:outputLabel for="tos" styleClass="form-check-label">
+                                    I agree to the <a href="#" class="link-primary">Terms of Service</a> and acknowledge the service level definitions.
+                                </h:outputLabel>
+                            </div>
+                            <h:commandButton value="Add to cart" styleClass="btn btn-primary btn-lg" />
+                        </h:form>
+                        <div class="mt-4">
+                            <h3 class="h5">Trust signals</h3>
+                            <ul class="list-unstyled small mb-0">
+                                <li>Secure payments processed via Veristore Pay</li>
+                                <li>Instant delivery with audit trail</li>
+                                <li>Money-back guarantee within 30 days</li>
+                            </ul>
+                        </div>
+                    </div>
+                </div>
+            </aside>
+        </div>
+    </ui:define>
+</ui:composition>

--- a/veristore/src/main/webapp/products.xhtml
+++ b/veristore/src/main/webapp/products.xhtml
@@ -20,7 +20,7 @@
                             <p id="filterHint" class="text-muted small">Refine results without leaving the blueprint layout.</p>
                             <div>
                                 <h:outputLabel for="country" value="Country of origin" styleClass="form-label" />
-                                <h:selectOneMenu id="country" styleClass="form-select">
+                                <h:selectOneMenu id="country" styleClass="form-select" value="#{productView.country}">
                                     <f:selectItem itemLabel="All" itemValue="" />
                                     <f:selectItem itemLabel="United States" itemValue="US" />
                                     <f:selectItem itemLabel="Germany" itemValue="DE" />
@@ -29,7 +29,7 @@
                             </div>
                             <div>
                                 <h:outputLabel for="category" value="Category" styleClass="form-label" />
-                                <h:selectOneMenu id="category" styleClass="form-select">
+                                <h:selectOneMenu id="category" styleClass="form-select" value="#{productView.category}">
                                     <f:selectItem itemLabel="All" itemValue="" />
                                     <f:selectItem itemLabel="Digital" itemValue="digital" />
                                     <f:selectItem itemLabel="Physical" itemValue="physical" />
@@ -40,53 +40,78 @@
                                 <h:outputLabel for="maxPrice" value="Max price" styleClass="form-label" />
                                 <div class="input-group">
                                     <span class="input-group-text" id="currencyLabel">$</span>
-                                    <h:inputText id="maxPrice" styleClass="form-control" pt:type="number" pt:min="0" pt:aria-describedby="currencyLabel" />
+                                    <h:inputText id="maxPrice" styleClass="form-control" value="#{productView.maxPrice}"
+                                                 pt:type="number" pt:min="0" pt:step="0.01"
+                                                 pt:aria-describedby="currencyLabel" />
                                 </div>
                             </div>
-                            <h:commandButton value="Apply filters" styleClass="btn btn-primary w-100" />
+                            <h:commandButton value="Apply filters" styleClass="btn btn-primary w-100" action="#{productView.applyFilters}" />
                         </fieldset>
                     </div>
                 </h:form>
             </aside>
             <section class="col-12 col-lg-9" aria-label="Product results">
-                <div class="row row-cols-1 row-cols-md-2 row-cols-xl-3 g-4">
-                    <ui:repeat value="#{['Enterprise Toolkit','Creator Starter Pack','Compliance Concierge','Wellness Monitoring','Digital Access Vault','Onsite Deployment']}" var="item" varStatus="status">
-                        <div class="col">
+                <h:panelGroup layout="block" rendered="#{empty productView.items}" styleClass="alert alert-info" role="status">
+                    No products match your filters yet. Adjust the filters and try again.
+                </h:panelGroup>
+                <div class="row row-cols-1 row-cols-md-2 row-cols-xl-3 g-4" role="list">
+                    <ui:repeat value="#{productView.items}" var="product" varStatus="status">
+                        <div class="col" role="listitem">
                             <article class="card h-100 shadow-sm border-0" aria-labelledby="productTitle#{status.index}">
+                                <ui:fragment rendered="#{not empty product.thumbnailUrl}">
+                                    <img src="#{product.thumbnailUrl}" alt="#{product.name}" class="card-img-top" />
+                                </ui:fragment>
+                                <ui:fragment rendered="#{empty product.thumbnailUrl}">
+                                    <div class="card-img-top bg-light d-flex align-items-center justify-content-center" style="min-height: 160px;">
+                                        <span class="text-muted">No image available</span>
+                                    </div>
+                                </ui:fragment>
                                 <div class="card-body d-flex flex-column">
-                                    <h2 id="productTitle#{status.index}" class="h5">#{item}</h2>
-                                    <p class="text-muted flex-grow-1">Trusted partner SKU with verified supply chain and dedicated support channel.</p>
+                                    <h2 id="productTitle#{status.index}" class="h5">#{product.name}</h2>
+                                    <p class="text-muted flex-grow-1">#{product.shortDesc}</p>
                                     <dl class="row small mb-3">
                                         <dt class="col-5">Country</dt>
-                                        <dd class="col-7">Global</dd>
+                                        <dd class="col-7">#{product.country}</dd>
                                         <dt class="col-5">Category</dt>
-                                        <dd class="col-7">Hybrid</dd>
+                                        <dd class="col-7">#{product.category}</dd>
                                     </dl>
                                     <div class="d-flex justify-content-between align-items-center mt-auto">
-                                        <span class="h5 mb-0">$199</span>
-                                        <h:link outcome="/product" styleClass="btn btn-outline-primary btn-sm">View</h:link>
+                                        <span class="h5 mb-0">#{product.priceFormatted}</span>
+                                        <h:link outcome="/product" styleClass="btn btn-outline-primary btn-sm">
+                                            <f:param name="sku" value="#{product.sku}" />
+                                            View
+                                        </h:link>
                                     </div>
                                 </div>
                             </article>
                         </div>
                     </ui:repeat>
                 </div>
-                <nav class="mt-4" role="navigation" aria-label="Pagination">
-                    <ul class="pagination justify-content-center mb-0">
-                        <li class="page-item disabled" aria-disabled="true">
-                            <span class="page-link">Previous</span>
-                        </li>
-                        <li class="page-item active" aria-current="page">
-                            <span class="page-link">1</span>
-                        </li>
-                        <li class="page-item">
-                            <h:link outcome="/products" value="2" styleClass="page-link" />
-                        </li>
-                        <li class="page-item">
-                            <h:link outcome="/products" value="Next" styleClass="page-link" />
-                        </li>
-                    </ul>
-                </nav>
+                <h:form id="paginationForm" rendered="#{productView.pages gt 1}" styleClass="mt-4">
+                    <nav role="navigation" aria-label="Pagination">
+                        <ul class="pagination justify-content-center mb-0">
+                            <li class="#{productView.hasPrev ? 'page-item' : 'page-item disabled'}" aria-disabled="#{productView.hasPrev ? 'false' : 'true'}">
+                                <ui:fragment rendered="#{productView.hasPrev}">
+                                    <h:commandLink value="Previous" styleClass="page-link" action="#{productView.prev}" />
+                                </ui:fragment>
+                                <ui:fragment rendered="#{not productView.hasPrev}">
+                                    <span class="page-link">Previous</span>
+                                </ui:fragment>
+                            </li>
+                            <li class="page-item active" aria-current="page">
+                                <span class="page-link">#{productView.page + 1} <span class="visually-hidden">of #{productView.pages}</span></span>
+                            </li>
+                            <li class="#{productView.hasNext ? 'page-item' : 'page-item disabled'}" aria-disabled="#{productView.hasNext ? 'false' : 'true'}">
+                                <ui:fragment rendered="#{productView.hasNext}">
+                                    <h:commandLink value="Next" styleClass="page-link" action="#{productView.next}" />
+                                </ui:fragment>
+                                <ui:fragment rendered="#{not productView.hasNext}">
+                                    <span class="page-link">Next</span>
+                                </ui:fragment>
+                            </li>
+                        </ul>
+                    </nav>
+                </h:form>
             </section>
         </div>
     </ui:define>

--- a/veristore/src/main/webapp/products.xhtml
+++ b/veristore/src/main/webapp/products.xhtml
@@ -1,0 +1,93 @@
+<!DOCTYPE html>
+<ui:composition xmlns="http://www.w3.org/1999/xhtml"
+                xmlns:h="http://xmlns.jcp.org/jsf/html"
+                xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+                xmlns:f="http://xmlns.jcp.org/jsf/core"
+                xmlns:pt="http://xmlns.jcp.org/jsf/passthrough"
+                template="/WEB-INF/template.xhtml">
+    <ui:define name="title">Products &ndash; Veristore catalog</ui:define>
+    <ui:define name="content">
+        <header class="mb-4" aria-labelledby="catalogHeading">
+            <h1 id="catalogHeading" class="h2 mb-2">Product catalog</h1>
+            <p class="text-muted mb-0">Filter by origin, category, and spend limits to match your fulfillment strategy.</p>
+        </header>
+        <div class="row g-4">
+            <aside class="col-12 col-lg-3">
+                <h:form id="filters" class="card shadow-sm border-0" role="search">
+                    <div class="card-body">
+                        <fieldset class="vstack gap-3" aria-describedby="filterHint">
+                            <legend class="h5">Filters</legend>
+                            <p id="filterHint" class="text-muted small">Refine results without leaving the blueprint layout.</p>
+                            <div>
+                                <h:outputLabel for="country" value="Country of origin" styleClass="form-label" />
+                                <h:selectOneMenu id="country" styleClass="form-select">
+                                    <f:selectItem itemLabel="All" itemValue="" />
+                                    <f:selectItem itemLabel="United States" itemValue="US" />
+                                    <f:selectItem itemLabel="Germany" itemValue="DE" />
+                                    <f:selectItem itemLabel="Japan" itemValue="JP" />
+                                </h:selectOneMenu>
+                            </div>
+                            <div>
+                                <h:outputLabel for="category" value="Category" styleClass="form-label" />
+                                <h:selectOneMenu id="category" styleClass="form-select">
+                                    <f:selectItem itemLabel="All" itemValue="" />
+                                    <f:selectItem itemLabel="Digital" itemValue="digital" />
+                                    <f:selectItem itemLabel="Physical" itemValue="physical" />
+                                    <f:selectItem itemLabel="Services" itemValue="services" />
+                                </h:selectOneMenu>
+                            </div>
+                            <div>
+                                <h:outputLabel for="maxPrice" value="Max price" styleClass="form-label" />
+                                <div class="input-group">
+                                    <span class="input-group-text" id="currencyLabel">$</span>
+                                    <h:inputText id="maxPrice" styleClass="form-control" pt:type="number" pt:min="0" pt:aria-describedby="currencyLabel" />
+                                </div>
+                            </div>
+                            <h:commandButton value="Apply filters" styleClass="btn btn-primary w-100" />
+                        </fieldset>
+                    </div>
+                </h:form>
+            </aside>
+            <section class="col-12 col-lg-9" aria-label="Product results">
+                <div class="row row-cols-1 row-cols-md-2 row-cols-xl-3 g-4">
+                    <ui:repeat value="#{['Enterprise Toolkit','Creator Starter Pack','Compliance Concierge','Wellness Monitoring','Digital Access Vault','Onsite Deployment']}" var="item" varStatus="status">
+                        <div class="col">
+                            <article class="card h-100 shadow-sm border-0" aria-labelledby="productTitle#{status.index}">
+                                <div class="card-body d-flex flex-column">
+                                    <h2 id="productTitle#{status.index}" class="h5">#{item}</h2>
+                                    <p class="text-muted flex-grow-1">Trusted partner SKU with verified supply chain and dedicated support channel.</p>
+                                    <dl class="row small mb-3">
+                                        <dt class="col-5">Country</dt>
+                                        <dd class="col-7">Global</dd>
+                                        <dt class="col-5">Category</dt>
+                                        <dd class="col-7">Hybrid</dd>
+                                    </dl>
+                                    <div class="d-flex justify-content-between align-items-center mt-auto">
+                                        <span class="h5 mb-0">$199</span>
+                                        <h:link outcome="/product" styleClass="btn btn-outline-primary btn-sm">View</h:link>
+                                    </div>
+                                </div>
+                            </article>
+                        </div>
+                    </ui:repeat>
+                </div>
+                <nav class="mt-4" role="navigation" aria-label="Pagination">
+                    <ul class="pagination justify-content-center mb-0">
+                        <li class="page-item disabled" aria-disabled="true">
+                            <span class="page-link">Previous</span>
+                        </li>
+                        <li class="page-item active" aria-current="page">
+                            <span class="page-link">1</span>
+                        </li>
+                        <li class="page-item">
+                            <h:link outcome="/products" value="2" styleClass="page-link" />
+                        </li>
+                        <li class="page-item">
+                            <h:link outcome="/products" value="Next" styleClass="page-link" />
+                        </li>
+                    </ul>
+                </nav>
+            </section>
+        </div>
+    </ui:define>
+</ui:composition>

--- a/veristore/src/main/webapp/resources/bootstrap/css/bootstrap.min.css
+++ b/veristore/src/main/webapp/resources/bootstrap/css/bootstrap.min.css
@@ -1,0 +1,1 @@
+/* Placeholder for Bootstrap 5 CSS. Replace with actual Bootstrap distribution for production use. */

--- a/veristore/src/main/webapp/resources/bootstrap/js/bootstrap.bundle.min.js
+++ b/veristore/src/main/webapp/resources/bootstrap/js/bootstrap.bundle.min.js
@@ -1,0 +1,1 @@
+// Placeholder for Bootstrap 5 bundle JS. Replace with actual Bootstrap distribution for production use.


### PR DESCRIPTION
## Summary
- integrate the site template with Bootstrap-styled h:messages, skip navigation, and shared assets
- refresh navbar, footer, and storefront pages to mirror the blueprint structure with responsive, accessible sections
- update product filters, purchase forms, checkout flow, and order confirmation actions for clearer scaffolding

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e04df0fa9c8330a3355c1cbfcb0500